### PR TITLE
Add boot_config and enum with new manual_forced

### DIFF
--- a/aiohasupervisor/models/__init__.py
+++ b/aiohasupervisor/models/__init__.py
@@ -2,6 +2,7 @@
 
 from aiohasupervisor.models.addons import (
     AddonBoot,
+    AddonBootConfig,
     AddonsConfigValidate,
     AddonsOptions,
     AddonsSecurityOptions,
@@ -42,6 +43,7 @@ __all__ = [
     "AvailableUpdate",
     "AddonStage",
     "AddonBoot",
+    "AddonBootConfig",
     "CpuArch",
     "Capability",
     "AppArmor",

--- a/aiohasupervisor/models/addons.py
+++ b/aiohasupervisor/models/addons.py
@@ -20,6 +20,14 @@ class AddonStage(StrEnum):
     DEPRECATED = "deprecated"
 
 
+class AddonBootConfig(StrEnum):
+    """AddonBootConfig type."""
+
+    AUTO = "auto"
+    MANUAL = "manual"
+    MANUAL_FORCED = "manual_forced"
+
+
 class AddonBoot(StrEnum):
     """AddonBoot type."""
 
@@ -197,6 +205,7 @@ class InstalledAddonComplete(
     dns: list[str]
     protected: bool
     boot: AddonBoot
+    boot_config: AddonBootConfig
     options: dict[str, Any]
     schema: list[dict[str, Any]] | None
     machine: list[str]


### PR DESCRIPTION
# Proposed Changes

Add new `boot_config` field and matching `AddonBootConfig` enum with `manual_forced` option added in https://github.com/home-assistant/supervisor/pull/5272
