### PR TITLE
Fix tag reference in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           with open("pyproject.toml", "rb") as f:
             pyproject = tomli.load(f)
 
-          pyproject["project"]["version"] = "${tag}"
+          pyproject["project"]["version"] = "${{ env.tag }}"
 
           with open("pyproject.toml", "wb") as f:
             tomli_w.dump(pyproject, f)


### PR DESCRIPTION
# Proposed Changes

Shell is python not bash there, can't reference envs like that. Use syntax to have github actions process that reference first
