### PR TITLE
Lower python requirements to 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 concurrency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
         description: "Version for release on TestPyPI"
         required: true
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py312-plus
+          - --py311-plus
           - --force
           - --keep-updates
         files: ^(aiohasupervisor|script|tests)/.+\.py$

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:1-3.12
+FROM mcr.microsoft.com/devcontainers/python:1-3.11
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "The Home Assistant Authors", email = "hello@home-assistant.io" },
 ]
 keywords = ["docker", "home-assistant", "api", "client-library"]
-requires-python = ">=3.12.0"
+requires-python = ">=3.11.0"
 dependencies = [
     "aiohttp>=3.3.0,<4.0.0",
     "mashumaro>=3.11,<4.0",


### PR DESCRIPTION
# Proposed Changes

Home Assistant currently supports python 3.11 and 3.12. So python version needs to be lowered to 3.11 to match.