### PR TITLE
Ensure provided uris match their normalized version

### DIFF
--- a/aiohasupervisor/client.py
+++ b/aiohasupervisor/client.py
@@ -79,7 +79,7 @@ class _SupervisorClient:
         # string that was passed in. If they are different, then the passed in uri
         # contained characters that were removed by the normalization
         # such as ../../../../etc/passwd
-        if url.raw_path != uri:
+        if not url.raw_path.endswith(uri):
             raise SupervisorError(f"Invalid request {uri}")
 
         match response_type:

--- a/aiohasupervisor/client.py
+++ b/aiohasupervisor/client.py
@@ -70,7 +70,17 @@ class _SupervisorClient:
         data: Any = None,
     ) -> Response:
         """Handle a request to Supervisor."""
-        url = URL(self.api_host).joinpath(uri)
+        try:
+            url = URL(self.api_host).joinpath(uri)
+        except ValueError as err:
+            raise SupervisorError from err
+
+        # This check is to make sure the normalized URL string is the same as the URL
+        # string that was passed in. If they are different, then the passed in uri
+        # contained characters that were removed by the normalization
+        # such as ../../../../etc/passwd
+        if url.raw_path != uri:
+            raise SupervisorError(f"Invalid request {uri}")
 
         match response_type:
             case ResponseType.TEXT:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,24 @@
+"""Tests for client."""
+
+import pytest
+
+from aiohasupervisor.client import _SupervisorClient
+from aiohasupervisor.exceptions import SupervisorError
+
+from .const import SUPERVISOR_URL
+
+
+@pytest.mark.parametrize("method", ["get", "post", "put", "delete"])
+async def test_path_manipulation_blocked(method: str) -> None:
+    """Test path manipulation prevented."""
+    client = _SupervisorClient(SUPERVISOR_URL, "abc123", 10)
+    action = getattr(client, method)
+    with pytest.raises(SupervisorError):
+        # absolute path
+        await action("/test/../bad")
+    with pytest.raises(SupervisorError):
+        # relative path
+        await action("test/../bad")
+    with pytest.raises(SupervisorError):
+        # relative path with percent encoding
+        await action("test/%2E%2E/bad")


### PR DESCRIPTION
# Proposed Changes

Ensure uris provided match their normalized versiont to prevent path manipulation attacks as sometimes parts of the resource path may come from user input, such as addon slugs.
