### PR TITLE
Add by alias flag to addon to dict

### DIFF
--- a/aiohasupervisor/models/addons.py
+++ b/aiohasupervisor/models/addons.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from typing import Any
 
 from mashumaro import field_options
+from mashumaro.config import TO_DICT_ADD_BY_ALIAS_FLAG, BaseConfig
 
 from .base import DEFAULT, Options, Request, RequestConfig, ResponseData
 
@@ -150,6 +151,11 @@ class AddonInfoStoreExtFields(ABC):
     supervisor_role: SupervisorRole = field(
         metadata=field_options(alias="hassio_role"),
     )
+
+    class Config(BaseConfig):
+        """Mashumaro config options."""
+
+        code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]  # noqa: RUF012
 
 
 @dataclass(frozen=True)

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -12,8 +12,11 @@ from aiohasupervisor.models import (
     AddonState,
     AddonsUninstall,
     Capability,
+    InstalledAddonComplete,
+    StoreAddonComplete,
     SupervisorRole,
 )
+from aiohasupervisor.models.base import Response
 
 from . import load_fixture
 from .const import SUPERVISOR_URL
@@ -234,3 +237,20 @@ async def test_addons_stats(
     assert stats.cpu_percent == 0
     assert stats.memory_usage == 24588288
     assert stats.network_rx == 1717120021
+
+
+async def test_addons_serialize_by_alias() -> None:
+    """Test serializing addons by alias."""
+    response = Response.from_json(load_fixture("store_addon_info.json"))
+    store_addon_info = StoreAddonComplete.from_dict(response.data)
+
+    assert store_addon_info.supervisor_api is False
+    assert (store_addon_info.to_dict())["supervisor_api"] is False
+    assert (store_addon_info.to_dict(by_alias=True))["hassio_api"] is False
+
+    response = Response.from_json(load_fixture("addons_info.json"))
+    addon_info = InstalledAddonComplete.from_dict(response.data)
+
+    assert addon_info.supervisor_api is True
+    assert (addon_info.to_dict())["supervisor_api"] is True
+    assert (addon_info.to_dict(by_alias=True))["hassio_api"] is True


### PR DESCRIPTION
# Proposed Changes

Core serializes the responses from our APIs into a data store for caching. Other integrations are able to access this data store outside of the hassio integration. Therefore in order to maintain backwards compatibility we need to be serialize by alias when storing addon info responses in this data structure.
