### PR TITLE
Fix type of Addon.ip_address

### DIFF
--- a/aiohasupervisor/models/addons.py
+++ b/aiohasupervisor/models/addons.py
@@ -3,6 +3,7 @@
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import StrEnum
+from ipaddress import IPv4Address
 from typing import Any
 
 from mashumaro import field_options
@@ -242,7 +243,7 @@ class InstalledAddonComplete(
     audio_input: str | None
     audio_output: str | None
     auto_update: bool
-    ip_address: bool
+    ip_address: IPv4Address
     watchdog: bool
     devices: list[str]
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1,5 +1,7 @@
 """Test addons supervisor client."""
 
+from ipaddress import IPv4Address
+
 from aioresponses import aioresponses
 from yarl import URL
 
@@ -55,7 +57,7 @@ async def test_addons_info(
     assert addon.changelog is True
     assert addon.watchdog is False
     assert addon.auto_update is False
-    assert addon.ip_address == "172.30.33.0"
+    assert addon.ip_address == IPv4Address("172.30.33.0")
     assert Capability.NET_RAW in addon.privileged
     assert "not_real" in addon.privileged
     assert addon.supervisor_api is True


### PR DESCRIPTION
# Proposed Changes

Typing of `ip_address` field in Addon info was completely incorrect, it is not a `bool`. Unfortunately this is a breaking change since it appears it allowed a string in despite the typing and now it is correctly made into an `IPv4Address`. I think that's ok since we're still in very early versions but I can make a `str` if we prefer.
