### PR TITLE
Remove DiscoveryList from exposed models

### DIFF
--- a/aiohasupervisor/models/__init__.py
+++ b/aiohasupervisor/models/__init__.py
@@ -176,5 +176,4 @@ __all__ = [
     "PartialRestoreOptions",
     "Discovery",
     "DiscoveryConfig",
-    "DiscoveryList",
 ]


### PR DESCRIPTION
# Proposed Changes

Tiny tweak. After changes in #16 I forgot to remove `DiscoveryList` from `__all__`
