### PR TITLE
Rename action methods without verb

### DIFF
--- a/aiohasupervisor/addons.py
+++ b/aiohasupervisor/addons.py
@@ -52,7 +52,7 @@ class AddonsClient(_SupervisorComponentClient):
         """Restart an addon."""
         await self._client.post(f"addons/{addon}/restart")
 
-    async def addon_options(self, addon: str, options: AddonsOptions) -> None:
+    async def set_addon_options(self, addon: str, options: AddonsOptions) -> None:
         """Set options for addon."""
         await self._client.post(f"addons/{addon}/options", json=options.to_dict())
 
@@ -78,11 +78,13 @@ class AddonsClient(_SupervisorComponentClient):
         """Rebuild an addon (only available for local addons built from source)."""
         await self._client.post(f"addons/{addon}/rebuild")
 
-    async def addon_stdin(self, addon: str, stdin: bytes) -> None:
+    async def write_addon_stdin(self, addon: str, stdin: bytes) -> None:
         """Write to stdin of an addon (if supported by addon)."""
         await self._client.post(f"addons/{addon}/stdin", data=stdin)
 
-    async def addon_security(self, addon: str, options: AddonsSecurityOptions) -> None:
+    async def set_addon_security(
+        self, addon: str, options: AddonsSecurityOptions
+    ) -> None:
         """Set security options for addon."""
         await self._client.post(f"addons/{addon}/security", json=options.to_dict())
 
@@ -90,10 +92,5 @@ class AddonsClient(_SupervisorComponentClient):
         """Get stats for addon."""
         result = await self._client.get(f"addons/{addon}/stats")
         return AddonsStats.from_dict(result.data)
-
-    # Aliases for clarity
-    set_addon_options = addon_options
-    write_addon_stdin = addon_stdin
-    set_addon_security = addon_security
 
     # Omitted for now - Log endpoints

--- a/aiohasupervisor/addons.py
+++ b/aiohasupervisor/addons.py
@@ -91,4 +91,9 @@ class AddonsClient(_SupervisorComponentClient):
         result = await self._client.get(f"addons/{addon}/stats")
         return AddonsStats.from_dict(result.data)
 
+    # Aliases for clarity
+    set_addon_options = addon_options
+    write_addon_stdin = addon_stdin
+    set_addon_security = addon_security
+
     # Omitted for now - Log endpoints

--- a/aiohasupervisor/backups.py
+++ b/aiohasupervisor/backups.py
@@ -31,7 +31,7 @@ class BackupsClient(_SupervisorComponentClient):
         result = await self._client.get("backups/info")
         return BackupsInfo.from_dict(result.data)
 
-    async def options(self, options: BackupsOptions) -> None:
+    async def set_options(self, options: BackupsOptions) -> None:
         """Set options for backups."""
         await self._client.post("backups/options", json=options.to_dict())
 

--- a/aiohasupervisor/homeassistant.py
+++ b/aiohasupervisor/homeassistant.py
@@ -25,7 +25,7 @@ class HomeAssistantClient(_SupervisorComponentClient):
         result = await self._client.get("core/stats")
         return HomeAssistantStats.from_dict(result.data)
 
-    async def options(self, options: HomeAssistantOptions) -> None:
+    async def set_options(self, options: HomeAssistantOptions) -> None:
         """Set Home Assistant options."""
         await self._client.post("core/options", json=options.to_dict())
 

--- a/aiohasupervisor/host.py
+++ b/aiohasupervisor/host.py
@@ -35,7 +35,7 @@ class HostClient(_SupervisorComponentClient):
         """Reload host info cache."""
         await self._client.post("host/reload")
 
-    async def options(self, options: HostOptions) -> None:
+    async def set_options(self, options: HostOptions) -> None:
         """Set host options."""
         await self._client.post("host/options", json=options.to_dict())
 

--- a/aiohasupervisor/os.py
+++ b/aiohasupervisor/os.py
@@ -55,7 +55,7 @@ class OSClient(_SupervisorComponentClient):
         result = await self._client.get("os/boards/green")
         return GreenInfo.from_dict(result.data)
 
-    async def green_options(self, options: GreenOptions) -> None:
+    async def set_green_options(self, options: GreenOptions) -> None:
         """Set options for green board (if in use)."""
         await self._client.post("os/boards/green", json=options.to_dict())
 
@@ -64,6 +64,6 @@ class OSClient(_SupervisorComponentClient):
         result = await self._client.get("os/boards/yellow")
         return YellowInfo.from_dict(result.data)
 
-    async def yellow_options(self, options: YellowOptions) -> None:
+    async def set_yellow_options(self, options: YellowOptions) -> None:
         """Set options for yellow board (if in use)."""
         await self._client.post("os/boards/yellow", json=options.to_dict())

--- a/aiohasupervisor/supervisor.py
+++ b/aiohasupervisor/supervisor.py
@@ -46,7 +46,7 @@ class SupervisorManagementClient(_SupervisorComponentClient):
         """Restart supervisor."""
         await self._client.post("supervisor/restart")
 
-    async def options(self, options: SupervisorOptions) -> None:
+    async def set_options(self, options: SupervisorOptions) -> None:
         """Set supervisor options."""
         await self._client.post("supervisor/options", json=options.to_dict())
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -119,7 +119,7 @@ async def test_addons_options(
     """Test addon options API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/options", status=200)
     assert (
-        await supervisor_client.addons.addon_options(
+        await supervisor_client.addons.set_addon_options(
             "core_ssh",
             AddonsOptions(
                 config=None,
@@ -195,7 +195,8 @@ async def test_addons_stdin(
     """Test addon stdin API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/stdin", status=200)
     assert (
-        await supervisor_client.addons.addon_stdin("core_ssh", b"hello world") is None
+        await supervisor_client.addons.write_addon_stdin("core_ssh", b"hello world")
+        is None
     )
     assert len(responses.requests) == 1
     assert (
@@ -212,7 +213,7 @@ async def test_addons_security(
     """Test addon security API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/security", status=200)
     assert (
-        await supervisor_client.addons.addon_security(
+        await supervisor_client.addons.set_addon_security(
             "core_ssh", AddonsSecurityOptions(protected=True)
         )
         is None

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -60,7 +60,7 @@ async def test_backups_options(
     """Test backups options API."""
     responses.post(f"{SUPERVISOR_URL}/backups/options", status=200)
     assert (
-        await supervisor_client.backups.options(BackupsOptions(days_until_stale=10))
+        await supervisor_client.backups.set_options(BackupsOptions(days_until_stale=10))
         is None
     )
     assert responses.requests.keys() == {

--- a/tests/test_homeassistant.py
+++ b/tests/test_homeassistant.py
@@ -61,7 +61,7 @@ async def test_homeassistant_options(
     """Test Home Assistant options API."""
     responses.post(f"{SUPERVISOR_URL}/core/options", status=200)
     assert (
-        await supervisor_client.homeassistant.options(
+        await supervisor_client.homeassistant.set_options(
             HomeAssistantOptions(watchdog=False, backups_exclude_database=True)
         )
         is None

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -87,7 +87,9 @@ async def test_host_options(
 ) -> None:
     """Test host options API."""
     responses.post(f"{SUPERVISOR_URL}/host/options", status=200)
-    assert await supervisor_client.host.options(HostOptions(hostname="test")) is None
+    assert (
+        await supervisor_client.host.set_options(HostOptions(hostname="test")) is None
+    )
     assert responses.requests.keys() == {
         ("POST", URL(f"{SUPERVISOR_URL}/host/options"))
     }

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -141,7 +141,7 @@ async def test_os_green_options(
     """Test OS green board options API."""
     responses.post(f"{SUPERVISOR_URL}/os/boards/green", status=200)
     assert (
-        await supervisor_client.os.green_options(GreenOptions(activity_led=False))
+        await supervisor_client.os.set_green_options(GreenOptions(activity_led=False))
         is None
     )
     assert responses.requests.keys() == {
@@ -170,7 +170,9 @@ async def test_os_yellow_options(
     """Test OS yellow board options API."""
     responses.post(f"{SUPERVISOR_URL}/os/boards/yellow", status=200)
     assert (
-        await supervisor_client.os.yellow_options(YellowOptions(heartbeat_led=False))
+        await supervisor_client.os.set_yellow_options(
+            YellowOptions(heartbeat_led=False)
+        )
         is None
     )
     assert responses.requests.keys() == {

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -105,7 +105,7 @@ async def test_supervisor_options(
     """Test supervisor options API."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/options", status=200)
     assert (
-        await supervisor_client.supervisor.options(
+        await supervisor_client.supervisor.set_options(
             SupervisorOptions(debug=True, debug_block=True)
         )
         is None


### PR DESCRIPTION
# Proposed Changes

Several action methods (mostly around options) did not begin with a verb which is confusing. As 1.0 has not been shipped yet, renaming them for clarity. 