### PR TITLE
Set appropriate timeouts for clients without option

### DIFF
--- a/aiohasupervisor/addons.py
+++ b/aiohasupervisor/addons.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from .client import _SupervisorComponentClient
-from .const import ResponseType
+from .const import TIMEOUT_60_SECONDS, ResponseType
 from .models.addons import (
     AddonsConfigValidate,
     AddonsList,
@@ -38,19 +38,20 @@ class AddonsClient(_SupervisorComponentClient):
         await self._client.post(
             f"addons/{addon}/uninstall",
             json=options.to_dict() if options else None,
+            timeout=TIMEOUT_60_SECONDS,
         )
 
     async def start_addon(self, addon: str) -> None:
         """Start an addon."""
-        await self._client.post(f"addons/{addon}/start")
+        await self._client.post(f"addons/{addon}/start", timeout=TIMEOUT_60_SECONDS)
 
     async def stop_addon(self, addon: str) -> None:
         """Stop an addon."""
-        await self._client.post(f"addons/{addon}/stop")
+        await self._client.post(f"addons/{addon}/stop", timeout=TIMEOUT_60_SECONDS)
 
     async def restart_addon(self, addon: str) -> None:
         """Restart an addon."""
-        await self._client.post(f"addons/{addon}/restart")
+        await self._client.post(f"addons/{addon}/restart", timeout=None)
 
     async def addon_options(self, addon: str, options: AddonsOptions) -> None:
         """Set options for addon."""

--- a/aiohasupervisor/backups.py
+++ b/aiohasupervisor/backups.py
@@ -55,6 +55,7 @@ class BackupsClient(_SupervisorComponentClient):
             "backups/new/full",
             json=options.to_dict() if options else None,
             response_type=ResponseType.JSON,
+            timeout=None,
         )
         return NewBackup.from_dict(result.data)
 
@@ -64,6 +65,7 @@ class BackupsClient(_SupervisorComponentClient):
             "backups/new/partial",
             json=options.to_dict(),
             response_type=ResponseType.JSON,
+            timeout=None,
         )
         return NewBackup.from_dict(result.data)
 
@@ -84,6 +86,7 @@ class BackupsClient(_SupervisorComponentClient):
             f"backups/{backup}/restore/full",
             json=options.to_dict() if options else None,
             response_type=ResponseType.JSON,
+            timeout=None,
         )
         return BackupJob.from_dict(result.data)
 
@@ -95,6 +98,7 @@ class BackupsClient(_SupervisorComponentClient):
             f"backups/{backup}/restore/partial",
             json=options.to_dict(),
             response_type=ResponseType.JSON,
+            timeout=None,
         )
         return BackupJob.from_dict(result.data)
 

--- a/aiohasupervisor/client.py
+++ b/aiohasupervisor/client.py
@@ -14,7 +14,7 @@ from aiohttp import (
 )
 from yarl import URL
 
-from .const import ResponseType
+from .const import DEFAULT_TIMEOUT, ResponseType
 from .exceptions import (
     SupervisorAuthenticationError,
     SupervisorBadRequestError,
@@ -50,14 +50,8 @@ class _SupervisorClient:
 
     api_host: str
     token: str
-    request_timeout: int
     session: ClientSession | None = None
     _close_session: bool = field(default=False, init=False)
-
-    @property
-    def timeout(self) -> ClientTimeout:
-        """Timeout for requests."""
-        return ClientTimeout(total=self.request_timeout)
 
     async def _request(
         self,
@@ -68,6 +62,7 @@ class _SupervisorClient:
         response_type: ResponseType,
         json: dict[str, Any] | None = None,
         data: Any = None,
+        timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a request to Supervisor."""
         try:
@@ -102,7 +97,7 @@ class _SupervisorClient:
             async with self.session.request(
                 method.value,
                 url,
-                timeout=self.timeout,
+                timeout=timeout,
                 headers=headers,
                 params=params,
                 json=json,
@@ -153,6 +148,7 @@ class _SupervisorClient:
         *,
         params: dict[str, str] | None = None,
         response_type: ResponseType = ResponseType.JSON,
+        timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a GET request to Supervisor."""
         return await self._request(
@@ -160,6 +156,7 @@ class _SupervisorClient:
             uri,
             params=params,
             response_type=response_type,
+            timeout=timeout,
         )
 
     async def post(
@@ -170,6 +167,7 @@ class _SupervisorClient:
         response_type: ResponseType = ResponseType.NONE,
         json: dict[str, Any] | None = None,
         data: Any = None,
+        timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a POST request to Supervisor."""
         return await self._request(
@@ -179,6 +177,7 @@ class _SupervisorClient:
             response_type=response_type,
             json=json,
             data=data,
+            timeout=timeout,
         )
 
     async def put(
@@ -187,6 +186,7 @@ class _SupervisorClient:
         *,
         params: dict[str, str] | None = None,
         json: dict[str, Any] | None = None,
+        timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a PUT request to Supervisor."""
         return await self._request(
@@ -195,6 +195,7 @@ class _SupervisorClient:
             params=params,
             response_type=ResponseType.NONE,
             json=json,
+            timeout=timeout,
         )
 
     async def delete(
@@ -202,6 +203,7 @@ class _SupervisorClient:
         uri: str,
         *,
         params: dict[str, str] | None = None,
+        timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a DELETE request to Supervisor."""
         return await self._request(
@@ -209,6 +211,7 @@ class _SupervisorClient:
             uri,
             params=params,
             response_type=ResponseType.NONE,
+            timeout=timeout,
         )
 
     async def close(self) -> None:

--- a/aiohasupervisor/const.py
+++ b/aiohasupervisor/const.py
@@ -2,6 +2,11 @@
 
 from enum import StrEnum
 
+from aiohttp import ClientTimeout
+
+DEFAULT_TIMEOUT = ClientTimeout(total=10)
+TIMEOUT_60_SECONDS = ClientTimeout(total=60)
+
 
 class ResponseType(StrEnum):
     """Expected response type."""

--- a/aiohasupervisor/discovery.py
+++ b/aiohasupervisor/discovery.py
@@ -3,7 +3,7 @@
 from uuid import UUID
 
 from .client import _SupervisorComponentClient
-from .const import ResponseType
+from .const import TIMEOUT_60_SECONDS, ResponseType
 from .models.discovery import Discovery, DiscoveryConfig, DiscoveryList, SetDiscovery
 
 
@@ -12,7 +12,7 @@ class DiscoveryClient(_SupervisorComponentClient):
 
     async def list(self) -> list[Discovery]:
         """List discovered active services."""
-        result = await self._client.get("discovery")
+        result = await self._client.get("discovery", timeout=TIMEOUT_60_SECONDS)
         return DiscoveryList.from_dict(result.data).discovery
 
     async def get(self, uuid: UUID) -> Discovery:

--- a/aiohasupervisor/homeassistant.py
+++ b/aiohasupervisor/homeassistant.py
@@ -32,7 +32,7 @@ class HomeAssistantClient(_SupervisorComponentClient):
     async def update(self, options: HomeAssistantUpdateOptions | None = None) -> None:
         """Update Home Assistant."""
         await self._client.post(
-            "core/update", json=options.to_dict() if options else None
+            "core/update", json=options.to_dict() if options else None, timeout=None
         )
 
     async def restart(self, options: HomeAssistantRestartOptions | None = None) -> None:

--- a/aiohasupervisor/host.py
+++ b/aiohasupervisor/host.py
@@ -1,6 +1,7 @@
 """Host client for supervisor."""
 
 from .client import _SupervisorComponentClient
+from .const import TIMEOUT_60_SECONDS
 from .models.host import (
     HostInfo,
     HostOptions,
@@ -22,7 +23,9 @@ class HostClient(_SupervisorComponentClient):
     async def reboot(self, options: RebootOptions | None = None) -> None:
         """Reboot host."""
         await self._client.post(
-            "host/reboot", json=options.to_dict() if options else None
+            "host/reboot",
+            json=options.to_dict() if options else None,
+            timeout=TIMEOUT_60_SECONDS,
         )
 
     async def shutdown(self, options: ShutdownOptions | None = None) -> None:

--- a/aiohasupervisor/os.py
+++ b/aiohasupervisor/os.py
@@ -26,7 +26,7 @@ class OSClient(_SupervisorComponentClient):
     async def update(self, options: OSUpdate | None = None) -> None:
         """Update OS."""
         await self._client.post(
-            "os/update", json=options.to_dict() if options else None
+            "os/update", json=options.to_dict() if options else None, timeout=None
         )
 
     async def config_sync(self) -> None:

--- a/aiohasupervisor/resolution.py
+++ b/aiohasupervisor/resolution.py
@@ -34,7 +34,7 @@ class ResolutionClient(_SupervisorComponentClient):
 
     async def apply_suggestion(self, suggestion: UUID) -> None:
         """Apply a suggestion."""
-        await self._client.post(f"resolution/suggestion/{suggestion.hex}")
+        await self._client.post(f"resolution/suggestion/{suggestion.hex}", timeout=None)
 
     async def dismiss_suggestion(self, suggestion: UUID) -> None:
         """Dismiss a suggestion."""

--- a/aiohasupervisor/root.py
+++ b/aiohasupervisor/root.py
@@ -2,7 +2,7 @@
 
 from typing import Self
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientTimeout
 
 from .addons import AddonsClient
 from .backups import BackupsClient
@@ -25,11 +25,10 @@ class SupervisorClient:
         self,
         api_host: str,
         token: str,
-        request_timeout: int = 10,
         session: ClientSession | None = None,
     ) -> None:
         """Initialize client."""
-        self._client = _SupervisorClient(api_host, token, request_timeout, session)
+        self._client = _SupervisorClient(api_host, token, session)
         self._addons = AddonsClient(self._client)
         self._os = OSClient(self._client)
         self._backups = BackupsClient(self._client)
@@ -98,7 +97,7 @@ class SupervisorClient:
 
     async def refresh_updates(self) -> None:
         """Refresh updates."""
-        await self._client.post("refresh_updates")
+        await self._client.post("refresh_updates", timeout=ClientTimeout(total=300))
 
     async def available_updates(self) -> list[AvailableUpdate]:
         """Get available updates."""

--- a/aiohasupervisor/store.py
+++ b/aiohasupervisor/store.py
@@ -47,14 +47,16 @@ class StoreClient(_SupervisorComponentClient):
 
     async def install_addon(self, addon: str) -> None:
         """Install an addon."""
-        await self._client.post(f"store/addons/{addon}/install")
+        await self._client.post(f"store/addons/{addon}/install", timeout=None)
 
     async def update_addon(
         self, addon: str, options: StoreAddonUpdate | None = None
     ) -> None:
         """Update an addon to latest version."""
         await self._client.post(
-            f"store/addons/{addon}/update", json=options.to_dict() if options else None
+            f"store/addons/{addon}/update",
+            json=options.to_dict() if options else None,
+            timeout=None,
         )
 
     async def reload(self) -> None:

--- a/aiohasupervisor/supervisor.py
+++ b/aiohasupervisor/supervisor.py
@@ -1,5 +1,7 @@
 """Supervisor client for supervisor."""
 
+from aiohttp import ClientTimeout
+
 from .client import _SupervisorComponentClient
 from .const import ResponseType
 from .models.supervisor import (
@@ -15,7 +17,11 @@ class SupervisorManagementClient(_SupervisorComponentClient):
 
     async def ping(self) -> None:
         """Check connection to supervisor."""
-        await self._client.get("supervisor/ping", response_type=ResponseType.NONE)
+        await self._client.get(
+            "supervisor/ping",
+            response_type=ResponseType.NONE,
+            timeout=ClientTimeout(total=15),
+        )
 
     async def info(self) -> SupervisorInfo:
         """Get supervisor info."""
@@ -35,7 +41,9 @@ class SupervisorManagementClient(_SupervisorComponentClient):
         latest version and ignore that field.
         """
         await self._client.post(
-            "supervisor/update", json=options.to_dict() if options else None
+            "supervisor/update",
+            json=options.to_dict() if options else None,
+            timeout=None,
         )
 
     async def reload(self) -> None:


### PR DESCRIPTION
# Proposed Changes

Remove the option to allow clients to set the timeout. Instead set appropriate timeouts for all API calls for users.

All timeout values are pulled from [Home Assistant Core's internal client library](https://github.com/home-assistant/core/blob/36ec1b33fe0039d838586730768730c2ea4e054c/homeassistant/components/hassio/handler.py) (viewing as it looked in 2024.9.0 before the migration to `aiohasupervisor` began). This is a breaking change but as 1.0 has not been shipped yet its preferrable to do this now.
