### PR TITLE
Add remove and download backup location

### DIFF
--- a/aiohasupervisor/client.py
+++ b/aiohasupervisor/client.py
@@ -212,6 +212,7 @@ class _SupervisorClient:
         uri: str,
         *,
         params: dict[str, str] | MultiDict[str] | None = None,
+        json: dict[str, Any] | None = None,
         timeout: ClientTimeout | None = DEFAULT_TIMEOUT,
     ) -> Response:
         """Handle a DELETE request to Supervisor."""
@@ -220,6 +221,7 @@ class _SupervisorClient:
             uri,
             params=params,
             response_type=ResponseType.NONE,
+            json=json,
             timeout=timeout,
         )
 

--- a/aiohasupervisor/models/__init__.py
+++ b/aiohasupervisor/models/__init__.py
@@ -33,6 +33,7 @@ from aiohasupervisor.models.backups import (
     BackupsInfo,
     BackupsOptions,
     BackupType,
+    DownloadBackupOptions,
     Folder,
     FreezeOptions,
     FullBackupOptions,
@@ -40,6 +41,7 @@ from aiohasupervisor.models.backups import (
     NewBackup,
     PartialBackupOptions,
     PartialRestoreOptions,
+    RemoveBackupOptions,
     UploadBackupOptions,
 )
 from aiohasupervisor.models.discovery import (
@@ -209,6 +211,7 @@ __all__ = [
     "BackupsInfo",
     "BackupsOptions",
     "BackupType",
+    "DownloadBackupOptions",
     "Folder",
     "FreezeOptions",
     "FullBackupOptions",
@@ -216,6 +219,7 @@ __all__ = [
     "NewBackup",
     "PartialBackupOptions",
     "PartialRestoreOptions",
+    "RemoveBackupOptions",
     "UploadBackupOptions",
     "Discovery",
     "DiscoveryConfig",

--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 
-from .base import Request, ResponseData
+from .base import DEFAULT, Request, ResponseData
 
 # --- ENUMS ----
 
@@ -135,7 +135,7 @@ class FullBackupOptions(Request):
     name: str | None = None
     password: str | None = None
     compressed: bool | None = None
-    location: set[str | None] | str | None = None
+    location: list[str | None] | str | None = DEFAULT  # type: ignore[assignment]
     homeassistant_exclude_database: bool | None = None
     background: bool | None = None
     extra: dict | None = None
@@ -185,3 +185,17 @@ class UploadedBackup(ResponseData):
     """UploadedBackup model."""
 
     slug: str
+
+
+@dataclass(frozen=True, slots=True)
+class RemoveBackupOptions(Request):
+    """RemoveBackupOptions model."""
+
+    location: set[str | None] = None
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadBackupOptions(Request):
+    """DownloadBackupOptions model."""
+
+    location: str | None = DEFAULT  # type: ignore[assignment]


### PR DESCRIPTION
# Proposed Changes

Add support for specifying location in remove and download backup APIs as per https://github.com/home-assistant/supervisor/pull/5482

In addition, fixes two issues with the `FullBackupOptions` and `PartialBackupOptions` models identified as part of this:
1. `None` was a valid option for location that did not get passed on to Supervisor. Now accepted.
2. `location` cannot be a `set`. Order matters as the first one in the list becomes the primary location of the backup. This is now unfortunately a breaking change to the beta from #33
