### PR TITLE
Add all addons option to partial backups

### DIFF
--- a/aiohasupervisor/models/__init__.py
+++ b/aiohasupervisor/models/__init__.py
@@ -25,6 +25,7 @@ from aiohasupervisor.models.addons import (
     SupervisorRole,
 )
 from aiohasupervisor.models.backups import (
+    AddonSet,
     Backup,
     BackupAddon,
     BackupComplete,
@@ -203,6 +204,7 @@ __all__ = [
     "GreenOptions",
     "YellowInfo",
     "YellowOptions",
+    "AddonSet",
     "Backup",
     "BackupAddon",
     "BackupComplete",

--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -26,6 +26,12 @@ class Folder(StrEnum):
     MEDIA = "media"
 
 
+class AddonSet(StrEnum):
+    """AddonSet type."""
+
+    ALL = "all"
+
+
 # --- OBJECTS ----
 
 
@@ -144,6 +150,8 @@ class FullBackupOptions(Request):
 @dataclass(frozen=True, slots=True)
 class PartialBackupOptions(FullBackupOptions, PartialBackupRestoreOptions):
     """PartialBackupOptions model."""
+
+    addons: set[str] | AddonSet | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -11,6 +11,7 @@ from yarl import URL
 
 from aiohasupervisor import SupervisorClient
 from aiohasupervisor.models import (
+    AddonSet,
     BackupsOptions,
     DownloadBackupOptions,
     Folder,
@@ -251,6 +252,10 @@ async def test_backups_full_backup(
         ),
         (
             PartialBackupOptions(name="Test", background=None, addons={"core_ssh"}),
+            "9ecf0028",
+        ),
+        (
+            PartialBackupOptions(name="Test", background=None, addons=AddonSet.ALL),
             "9ecf0028",
         ),
     ],


### PR DESCRIPTION
# Proposed Changes

Add support for "all addons" flag to partial backups as defined in https://github.com/home-assistant/supervisor/pull/5490
