### PR TITLE
Reverse order of typing when multiple can match

### DIFF
--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -141,7 +141,7 @@ class FullBackupOptions(Request):
     name: str | None = None
     password: str | None = None
     compressed: bool | None = None
-    location: list[str | None] | str | None = DEFAULT  # type: ignore[assignment]
+    location: str | list[str | None] | None = DEFAULT  # type: ignore[assignment]
     homeassistant_exclude_database: bool | None = None
     background: bool | None = None
     extra: dict | None = None
@@ -151,7 +151,7 @@ class FullBackupOptions(Request):
 class PartialBackupOptions(FullBackupOptions, PartialBackupRestoreOptions):
     """PartialBackupOptions model."""
 
-    addons: set[str] | AddonSet | None = None
+    addons: AddonSet | set[str] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -528,3 +528,30 @@ async def test_partial_backup_model(
     """Test partial backup model parsing and serializing."""
     assert PartialBackupOptions.from_dict(as_dict) == options
     assert options.to_dict() == as_dict
+
+
+@pytest.mark.parametrize(
+    ("options", "as_dict"),
+    [
+        (FullBackupOptions(name="Test"), {"name": "Test"}),
+        (FullBackupOptions(password="test"), {"password": "test"}),  # noqa: S106
+        (FullBackupOptions(compressed=True), {"compressed": True}),
+        (
+            FullBackupOptions(homeassistant_exclude_database=True),
+            {"homeassistant_exclude_database": True},
+        ),
+        (FullBackupOptions(background=True), {"background": True}),
+        (
+            FullBackupOptions(location=[".cloud_backup", "test"]),
+            {"location": [".cloud_backup", "test"]},
+        ),
+        (FullBackupOptions(location="test"), {"location": "test"}),
+        (FullBackupOptions(location=None), {"location": None}),
+    ],
+)
+async def test_full_backup_model(
+    options: FullBackupOptions, as_dict: dict[str, Any]
+) -> None:
+    """Test full backup model parsing and serializing."""
+    assert FullBackupOptions.from_dict(as_dict) == options
+    assert options.to_dict() == as_dict

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -483,3 +483,48 @@ async def test_download_backup(
     assert isinstance(result, AsyncIterator)
     async for chunk in result:
         assert chunk == b"backup test"
+
+
+@pytest.mark.parametrize(
+    ("options", "as_dict"),
+    [
+        (
+            PartialBackupOptions(name="Test", folders={Folder.SHARE}),
+            {"name": "Test", "folders": ["share"]},
+        ),
+        (PartialBackupOptions(addons={"core_ssh"}), {"addons": ["core_ssh"]}),
+        (PartialBackupOptions(addons=AddonSet.ALL), {"addons": "all"}),
+        (
+            PartialBackupOptions(
+                homeassistant=True, homeassistant_exclude_database=True
+            ),
+            {"homeassistant": True, "homeassistant_exclude_database": True},
+        ),
+        (
+            PartialBackupOptions(
+                folders={Folder.SSL}, compressed=True, background=True
+            ),
+            {"folders": ["ssl"], "compressed": True, "background": True},
+        ),
+        (
+            PartialBackupOptions(
+                homeassistant=True, location=[".cloud_backup", "test"]
+            ),
+            {"homeassistant": True, "location": [".cloud_backup", "test"]},
+        ),
+        (
+            PartialBackupOptions(homeassistant=True, location="test"),
+            {"homeassistant": True, "location": "test"},
+        ),
+        (
+            PartialBackupOptions(homeassistant=True, location=None),
+            {"homeassistant": True, "location": None},
+        ),
+    ],
+)
+async def test_partial_backup_model(
+    options: PartialBackupOptions, as_dict: dict[str, Any]
+) -> None:
+    """Test partial backup model parsing and serializing."""
+    assert PartialBackupOptions.from_dict(as_dict) == options
+    assert options.to_dict() == as_dict


### PR DESCRIPTION
# Proposed Changes

Strings also pass the typing test for `list[str]` or `set[str]` so typing order must be reversed to prevent incorrect parsing/serialization in any fields where both are accepted.
