### PR TITLE
ALL must be uppercase

### DIFF
--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -29,7 +29,7 @@ class Folder(StrEnum):
 class AddonSet(StrEnum):
     """AddonSet type."""
 
-    ALL = "all"
+    ALL = "ALL"
 
 
 # --- OBJECTS ----

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -493,7 +493,7 @@ async def test_download_backup(
             {"name": "Test", "folders": ["share"]},
         ),
         (PartialBackupOptions(addons={"core_ssh"}), {"addons": ["core_ssh"]}),
-        (PartialBackupOptions(addons=AddonSet.ALL), {"addons": "all"}),
+        (PartialBackupOptions(addons=AddonSet.ALL), {"addons": "ALL"}),
         (
             PartialBackupOptions(
                 homeassistant=True, homeassistant_exclude_database=True


### PR DESCRIPTION
# Proposed Changes

All addons flag needs `ALL` not `all`