### PR TITLE
Add protected locations field to backup model

### DIFF
--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -57,6 +57,7 @@ class BackupBaseFields(ABC):
     location: str | None
     locations: set[str | None]
     protected: bool
+    protected_locations: set[str | None]
     compressed: bool
 
 

--- a/tests/fixtures/backup_info.json
+++ b/tests/fixtures/backup_info.json
@@ -9,6 +9,7 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "protected_locations": [],
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backup_info_no_homeassistant.json
+++ b/tests/fixtures/backup_info_no_homeassistant.json
@@ -9,6 +9,7 @@
     "size_bytes": 120123,
     "compressed": true,
     "protected": false,
+    "protected_locations": [],
     "supervisor_version": "2023.08.2.dev1002",
     "homeassistant": null,
     "location": "Test",

--- a/tests/fixtures/backup_info_protected_locations.json
+++ b/tests/fixtures/backup_info_protected_locations.json
@@ -1,0 +1,29 @@
+{
+  "result": "ok",
+  "data": {
+    "slug": "d9c48f8b",
+    "type": "partial",
+    "name": "test_consolidate",
+    "date": "2025-01-22T18:09:28.196333+00:00",
+    "size": 0.01,
+    "size_bytes": 10240,
+    "compressed": true,
+    "protected": true,
+    "protected_locations": [null, "test"],
+    "supervisor_version": "2025.01.1.dev2104",
+    "homeassistant": null,
+    "location": null,
+    "locations": [null, "test"],
+    "addons": [],
+    "repositories": [
+      "https://github.com/esphome/home-assistant-addon",
+      "https://github.com/hassio-addons/repository",
+      "https://github.com/music-assistant/home-assistant-addon",
+      "local",
+      "core"
+    ],
+    "folders": ["ssl"],
+    "homeassistant_exclude_database": null,
+    "extra": {}
+  }
+}

--- a/tests/fixtures/backup_info_with_extra.json
+++ b/tests/fixtures/backup_info_with_extra.json
@@ -9,6 +9,7 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "protected_locations": [],
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backup_info_with_locations.json
+++ b/tests/fixtures/backup_info_with_locations.json
@@ -9,6 +9,7 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "protected_locations": [],
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backups_info.json
+++ b/tests/fixtures/backups_info.json
@@ -12,6 +12,7 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "protected_locations": [],
         "compressed": true,
         "content": {
           "homeassistant": true,
@@ -38,6 +39,7 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "protected_locations": [],
         "compressed": true,
         "content": {
           "homeassistant": false,

--- a/tests/fixtures/backups_list.json
+++ b/tests/fixtures/backups_list.json
@@ -12,6 +12,7 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "protected_locations": [],
         "compressed": true,
         "content": {
           "homeassistant": true,
@@ -38,6 +39,7 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "protected_locations": [],
         "compressed": true,
         "content": {
           "homeassistant": false,

--- a/tests/fixtures/backups_list_protected_locations.json
+++ b/tests/fixtures/backups_list_protected_locations.json
@@ -1,0 +1,25 @@
+{
+  "result": "ok",
+  "data": {
+    "backups": [
+      {
+        "slug": "d9c48f8b",
+        "name": "test_consolidate",
+        "date": "2025-01-22T18:09:28.196333+00:00",
+        "type": "partial",
+        "size": 0.01,
+        "size_bytes": 10240,
+        "location": null,
+        "locations": [null, "test"],
+        "protected": true,
+        "protected_locations": [null, "test"],
+        "compressed": true,
+        "content": {
+          "homeassistant": false,
+          "addons": [],
+          "folders": ["ssl"]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -555,3 +555,33 @@ async def test_full_backup_model(
     """Test full backup model parsing and serializing."""
     assert FullBackupOptions.from_dict(as_dict) == options
     assert options.to_dict() == as_dict
+
+
+async def test_backups_list_protected_locations(
+    responses: aioresponses,
+    supervisor_client: SupervisorClient,
+) -> None:
+    """Test protected locations field in backups list."""
+    responses.get(
+        f"{SUPERVISOR_URL}/backups",
+        status=200,
+        body=load_fixture("backups_list_protected_locations.json"),
+    )
+
+    result = await supervisor_client.backups.list()
+    assert result[0].protected_locations == {None, "test"}
+
+
+async def test_backup_info_protected_locations(
+    responses: aioresponses,
+    supervisor_client: SupervisorClient,
+) -> None:
+    """Test protected locations field in backup info."""
+    responses.get(
+        f"{SUPERVISOR_URL}/backups/d9c48f8b/info",
+        status=200,
+        body=load_fixture("backup_info_protected_locations.json"),
+    )
+
+    result = await supervisor_client.backups.backup_info("d9c48f8b")
+    assert result.protected_locations == {None, "test"}


### PR DESCRIPTION
# Proposed Changes

Add `protected_locations` field to model as per https://github.com/home-assistant/supervisor/pull/5569