### PR TITLE
Add filename input to upload backup API

### DIFF
--- a/aiohasupervisor/backups.py
+++ b/aiohasupervisor/backups.py
@@ -120,9 +120,12 @@ class BackupsClient(_SupervisorComponentClient):
     ) -> str:
         """Upload backup by stream and return slug."""
         params = MultiDict()
-        if options and options.location:
-            for location in options.location:
-                params.add("location", location or "")
+        if options:
+            if options.location:
+                for location in options.location:
+                    params.add("location", location or "")
+            if options.filename:
+                params.add("filename", options.filename.as_posix())
 
         with MultipartWriter("form-data") as mp:
             mp.append(stream)

--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -4,8 +4,9 @@ from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from pathlib import PurePath
 
-from .base import DEFAULT, Request, ResponseData
+from .base import DEFAULT, Options, Request, ResponseData
 
 # --- ENUMS ----
 
@@ -183,10 +184,11 @@ class PartialRestoreOptions(FullRestoreOptions, PartialBackupRestoreOptions):
 
 
 @dataclass(frozen=True, slots=True)
-class UploadBackupOptions(Request):
+class UploadBackupOptions(Options):
     """UploadBackupOptions model."""
 
     location: set[str | None] = None
+    filename: PurePath | None = None
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
# Proposed Changes

Add `filename` input to upload backup API as per https://github.com/home-assistant/supervisor/pull/5568
