### PR TITLE
Add location attributes field to backup model

### DIFF
--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -46,6 +46,14 @@ class BackupContent(ResponseData):
 
 
 @dataclass(frozen=True)
+class BackupLocationAttributes(ABC):
+    """BackupLocationAttributes model."""
+
+    protected: bool
+    size_bytes: int
+
+
+@dataclass(frozen=True)
 class BackupBaseFields(ABC):
     """BackupBaseFields ABC type."""
 
@@ -58,6 +66,7 @@ class BackupBaseFields(ABC):
     location: str | None
     locations: set[str | None]
     protected: bool
+    location_attributes: dict[str, BackupLocationAttributes]
     compressed: bool
 
 

--- a/tests/fixtures/backup_info.json
+++ b/tests/fixtures/backup_info.json
@@ -9,6 +9,12 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "location_attributes": {
+      ".local": {
+        "protected": false,
+        "size_bytes": 10123
+      }
+    },
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backup_info_location_attributes.json
+++ b/tests/fixtures/backup_info_location_attributes.json
@@ -1,0 +1,38 @@
+{
+  "result": "ok",
+  "data": {
+    "slug": "d9c48f8b",
+    "type": "partial",
+    "name": "test_consolidate",
+    "date": "2025-01-22T18:09:28.196333+00:00",
+    "size": 0.01,
+    "size_bytes": 10240,
+    "compressed": true,
+    "protected": true,
+    "location_attributes": {
+      ".local": {
+        "protected": true,
+        "size_bytes": 10240
+      },
+      "test": {
+        "protected": true,
+        "size_bytes": 10240
+      }
+    },
+    "supervisor_version": "2025.01.1.dev2104",
+    "homeassistant": null,
+    "location": null,
+    "locations": [null, "test"],
+    "addons": [],
+    "repositories": [
+      "https://github.com/esphome/home-assistant-addon",
+      "https://github.com/hassio-addons/repository",
+      "https://github.com/music-assistant/home-assistant-addon",
+      "local",
+      "core"
+    ],
+    "folders": ["ssl"],
+    "homeassistant_exclude_database": null,
+    "extra": {}
+  }
+}

--- a/tests/fixtures/backup_info_no_homeassistant.json
+++ b/tests/fixtures/backup_info_no_homeassistant.json
@@ -9,6 +9,12 @@
     "size_bytes": 120123,
     "compressed": true,
     "protected": false,
+    "location_attributes": {
+      ".local": {
+        "protected": false,
+        "size_bytes": 120123
+      }
+    },
     "supervisor_version": "2023.08.2.dev1002",
     "homeassistant": null,
     "location": "Test",

--- a/tests/fixtures/backup_info_with_extra.json
+++ b/tests/fixtures/backup_info_with_extra.json
@@ -9,6 +9,12 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "location_attributes": {
+      ".local": {
+        "protected": false,
+        "size_bytes": 10123
+      }
+    },
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backup_info_with_locations.json
+++ b/tests/fixtures/backup_info_with_locations.json
@@ -9,6 +9,16 @@
     "size_bytes": 10123,
     "compressed": true,
     "protected": false,
+    "location_attributes": {
+      ".local": {
+        "protected": false,
+        "size_bytes": 10123
+      },
+      "Test": {
+        "protected": false,
+        "size_bytes": 10123
+      }
+    },
     "supervisor_version": "2024.05.0",
     "homeassistant": null,
     "location": null,

--- a/tests/fixtures/backups_info.json
+++ b/tests/fixtures/backups_info.json
@@ -12,6 +12,12 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "location_attributes": {
+          ".local": {
+            "protected": false,
+            "size_bytes": 828810000
+          }
+        },
         "compressed": true,
         "content": {
           "homeassistant": true,
@@ -38,6 +44,12 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "location_attributes": {
+          ".local": {
+            "protected": false,
+            "size_bytes": 120123
+          }
+        },
         "compressed": true,
         "content": {
           "homeassistant": false,

--- a/tests/fixtures/backups_list.json
+++ b/tests/fixtures/backups_list.json
@@ -12,6 +12,12 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "location_attributes": {
+          ".local": {
+            "protected": false,
+            "size_bytes": 828810000
+          }
+        },
         "compressed": true,
         "content": {
           "homeassistant": true,
@@ -38,6 +44,12 @@
         "location": null,
         "locations": [null],
         "protected": false,
+        "location_attributes": {
+          ".local": {
+            "protected": false,
+            "size_bytes": 10123
+          }
+        },
         "compressed": true,
         "content": {
           "homeassistant": false,

--- a/tests/fixtures/backups_list_location_attributes.json
+++ b/tests/fixtures/backups_list_location_attributes.json
@@ -1,0 +1,34 @@
+{
+  "result": "ok",
+  "data": {
+    "backups": [
+      {
+        "slug": "d9c48f8b",
+        "name": "test_consolidate",
+        "date": "2025-01-22T18:09:28.196333+00:00",
+        "type": "partial",
+        "size": 0.01,
+        "size_bytes": 10240,
+        "location": null,
+        "locations": [null, "test"],
+        "protected": true,
+        "location_attributes": {
+          ".local": {
+            "protected": true,
+            "size_bytes": 10240
+          },
+          "test": {
+            "protected": true,
+            "size_bytes": 10240
+          }
+        },
+        "compressed": true,
+        "content": {
+          "homeassistant": false,
+          "addons": [],
+          "folders": ["ssl"]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Proposed Changes
The new location attributes field exposes attributes which can be different per location. This is mainly to enable encrypted/unencrypted backups per location, but we also expose size as an encrypted backup can be slightly different (a couple of bytes larger) in size.

As per https://github.com/home-assistant/supervisor/pull/5581
