### PR TITLE
Fix location attributes base class

### DIFF
--- a/aiohasupervisor/models/backups.py
+++ b/aiohasupervisor/models/backups.py
@@ -45,8 +45,8 @@ class BackupContent(ResponseData):
     folders: list[Folder]
 
 
-@dataclass(frozen=True)
-class BackupLocationAttributes(ABC):
+@dataclass(frozen=True, slots=True)
+class BackupLocationAttributes(ResponseData):
     """BackupLocationAttributes model."""
 
     protected: bool


### PR DESCRIPTION
# Proposed Changes

Use the regular `ResponseData` as base class. Also make sure to set the slots attribute like in other dataclasses.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
