### PR TITLE
Add API for /os/config/swap endpoints

### DIFF
--- a/aiohasupervisor/models/os.py
+++ b/aiohasupervisor/models/os.py
@@ -124,3 +124,19 @@ class YellowOptions(Options):
     disk_led: bool | None = None
     heartbeat_led: bool | None = None
     power_led: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SwapInfo(Options):
+    """SwapInfo model."""
+
+    swap_size: str | None
+    swappiness: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class SwapOptions(Options):
+    """SwapOptions model."""
+
+    swap_size: str | None = None
+    swappiness: int | None = None

--- a/aiohasupervisor/models/os.py
+++ b/aiohasupervisor/models/os.py
@@ -127,7 +127,7 @@ class YellowOptions(Options):
 
 
 @dataclass(frozen=True, slots=True)
-class SwapInfo(Options):
+class SwapInfo(ResponseData):
     """SwapInfo model."""
 
     swap_size: str | None

--- a/aiohasupervisor/os.py
+++ b/aiohasupervisor/os.py
@@ -10,6 +10,8 @@ from .models.os import (
     OSInfo,
     OSUpdate,
     SetBootSlotOptions,
+    SwapInfo,
+    SwapOptions,
     YellowInfo,
     YellowOptions,
 )
@@ -28,6 +30,15 @@ class OSClient(_SupervisorComponentClient):
         await self._client.post(
             "os/update", json=options.to_dict() if options else None, timeout=None
         )
+
+    async def swap_info(self) -> SwapInfo:
+        """Get swap settings."""
+        result = await self._client.get("os/config/swap")
+        return SwapInfo.from_dict(result.data)
+
+    async def set_swap_options(self, options: SwapOptions) -> None:
+        """Set swap settings."""
+        await self._client.post("os/config/swap", json=options.to_dict())
 
     async def config_sync(self) -> None:
         """Trigger config reload on OS."""

--- a/tests/fixtures/os_config_swap.json
+++ b/tests/fixtures/os_config_swap.json
@@ -1,0 +1,7 @@
+{
+  "result": "ok",
+  "data": {
+    "swappiness": 1,
+    "swap_size": "1G"
+  }
+}

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -15,6 +15,7 @@ from aiohasupervisor.models import (
     SetBootSlotOptions,
     YellowOptions,
 )
+from aiohasupervisor.models.os import SwapOptions
 
 from . import load_fixture
 from .const import SUPERVISOR_URL
@@ -49,6 +50,36 @@ async def test_os_update(
     responses.post(f"{SUPERVISOR_URL}/os/update", status=200)
     assert await supervisor_client.os.update(options) is None
     assert responses.requests.keys() == {("POST", URL(f"{SUPERVISOR_URL}/os/update"))}
+
+
+async def test_os_swap_info(
+    responses: aioresponses, supervisor_client: SupervisorClient
+) -> None:
+    """Test OS config swap API."""
+    responses.get(
+        f"{SUPERVISOR_URL}/os/config/swap",
+        status=200,
+        body=load_fixture("os_config_swap.json"),
+    )
+    info = await supervisor_client.os.swap_info()
+    assert info.swap_size == "1G"
+    assert info.swappiness == 1
+
+
+async def test_os_set_swap_options(
+    responses: aioresponses, supervisor_client: SupervisorClient
+) -> None:
+    """Test OS set swap options API."""
+    responses.post(f"{SUPERVISOR_URL}/os/config/swap", status=200)
+    assert (
+        await supervisor_client.os.set_swap_options(
+            SwapOptions(swap_size="1G", swappiness=20)
+        )
+        is None
+    )
+    assert responses.requests.keys() == {
+        ("POST", URL(f"{SUPERVISOR_URL}/os/config/swap"))
+    }
 
 
 async def test_os_config_sync(


### PR DESCRIPTION
# Proposed Changes

Add methods for endpoints implemented in home-assistant/supervisor#5770

## Related Issues

- home-assistant/supervisor#5770
