### PR TITLE
Drop yarl from explicit dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "aiohttp>=3.3.0,<4.0.0",
     "mashumaro>=3.11,<4.0",
     "orjson>=3.6.1,<4.0.0",
-    "yarl>=1.6.0,<2.0.0",
 ]
 # The version is set by GH action on release!
 version = "0.0.0"
@@ -27,7 +26,6 @@ dev = [
     "aiohttp==3.9.5",
     "mashumaro==3.13.1",
     "orjson==3.10.16",
-    "yarl==1.9.4",
 
     # Test requirements
     "aioresponses==0.7.6",


### PR DESCRIPTION
# Proposed Changes

This project doesn't use yarl directly, only via aiohttp. And yarl is already a dependency of aiohttp.
