### PR TITLE
Disk life time can be `None`

### DIFF
--- a/aiohasupervisor/models/host.py
+++ b/aiohasupervisor/models/host.py
@@ -45,7 +45,7 @@ class HostInfo(ResponseData):
     disk_free: float
     disk_total: float
     disk_used: float
-    disk_life_time: float
+    disk_life_time: float | None
     features: list[HostFeature]
     hostname: str | None
     llmnr_hostname: str | None


### PR DESCRIPTION
# Proposed Changes

Turns out `disk_life_time` can be `None`, the typing on the methods used to obtain it was inaccurate.
