### PR TITLE
Homeassistant machine and arch can be None

### DIFF
--- a/aiohasupervisor/models/homeassistant.py
+++ b/aiohasupervisor/models/homeassistant.py
@@ -15,9 +15,9 @@ class HomeAssistantInfo(ResponseData):
     version: str | None
     version_latest: str | None
     update_available: bool
-    machine: str
+    machine: str | None
     ip_address: IPv4Address
-    arch: str
+    arch: str | None
     image: str
     boot: bool
     port: int


### PR DESCRIPTION
# Proposed Changes

Running mypy identified typing issues and showed these two fields can be `None`. Correcting the library to account for this.
