### PR TITLE
Vlan parent can be `None`

### DIFF
--- a/aiohasupervisor/models/network.py
+++ b/aiohasupervisor/models/network.py
@@ -93,7 +93,7 @@ class Vlan(ResponseData):
     """Vlan model."""
 
     id: int
-    interface: str
+    interface: str | None
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
# Proposed Changes

Vlan parent interface can be `None` according to NM documentation.
