### PR TITLE
Add reload updates for main components

### DIFF
--- a/aiohasupervisor/root.py
+++ b/aiohasupervisor/root.py
@@ -117,11 +117,14 @@ class SupervisorClient:
         await self._client.post("reload_updates", timeout=ClientTimeout(total=300))
 
     async def refresh_updates(self) -> None:
-        """Refresh updates (discouraged)."""
+        """Refresh updates.
+
+        Discouraged. Use the `reload_updates()` and `store.reload()` instead.
+        """
         await self._client.post("refresh_updates", timeout=ClientTimeout(total=300))
 
     async def available_updates(self) -> list[AvailableUpdate]:
-        """Get available updates (discouraged)."""
+        """Get available updates."""
         result = await self._client.get("available_updates")
         return AvailableUpdates.from_dict(result.data).available_updates
 

--- a/aiohasupervisor/root.py
+++ b/aiohasupervisor/root.py
@@ -109,12 +109,19 @@ class SupervisorClient:
         result = await self._client.get("info")
         return RootInfo.from_dict(result.data)
 
+    async def reload_updates(self) -> None:
+        """Reload updates.
+
+        Reload main components update information (OS, Supervisor, Core and plug-ins).
+        """
+        await self._client.post("reload_updates", timeout=ClientTimeout(total=300))
+
     async def refresh_updates(self) -> None:
-        """Refresh updates."""
+        """Refresh updates (discouraged)."""
         await self._client.post("refresh_updates", timeout=ClientTimeout(total=300))
 
     async def available_updates(self) -> list[AvailableUpdate]:
-        """Get available updates."""
+        """Get available updates (discouraged)."""
         result = await self._client.get("available_updates")
         return AvailableUpdates.from_dict(result.data).available_updates
 

--- a/aiohasupervisor/root.py
+++ b/aiohasupervisor/root.py
@@ -119,7 +119,8 @@ class SupervisorClient:
     async def refresh_updates(self) -> None:
         """Refresh updates.
 
-        Discouraged. Use the `reload_updates()` and `store.reload()` instead.
+        Discouraged as this endpoint does two things at once. Use the `reload_updates()`
+        and `store.reload()` instead.
         """
         await self._client.post("refresh_updates", timeout=ClientTimeout(total=300))
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -88,6 +88,17 @@ async def test_available_updates(
     assert updates[1].update_type == UpdateType.OS
 
 
+async def test_reload_updates(
+    responses: aioresponses, supervisor_client: SupervisorClient
+) -> None:
+    """Test reload updates API."""
+    responses.post(f"{SUPERVISOR_URL}/reload_updates", status=200)
+    assert await supervisor_client.reload_updates() is None
+    assert responses.requests.keys() == {
+        ("POST", URL(f"{SUPERVISOR_URL}/reload_updates"))
+    }
+
+
 async def test_refresh_updates(
     responses: aioresponses, supervisor_client: SupervisorClient
 ) -> None:


### PR DESCRIPTION
# Proposed Changes

Add /reload_updates endpoint which refreshes updates of the main components only (OS, Supervisor, Core and Plug-ins).
