### PR TITLE
Add unsupported reason os_version

### DIFF
--- a/aiohasupervisor/models/resolution.py
+++ b/aiohasupervisor/models/resolution.py
@@ -94,6 +94,7 @@ class UnsupportedReason(StrEnum):
     NETWORK_MANAGER = "network_manager"
     OS = "os"
     OS_AGENT = "os_agent"
+    OS_VERSION = "os_version"
     PRIVILEGED = "privileged"
     RESTART_POLICY = "restart_policy"
     SOFTWARE = "software"


### PR DESCRIPTION
# Proposed Changes

Add `UnsupportedReason.OS_VERSION` as added in https://github.com/home-assistant/supervisor/pull/6041
