### PR TITLE
Remove 'enhancement' label from labels configuration

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,9 +10,6 @@
 - name: "documentation"
   color: 0052cc
   description: "Solely about the documentation of the project."
-- name: "enhancement"
-  color: 1d76db
-  description: "Enhancement of the code, not introducing new features."
 - name: "refactor"
   color: 1d76db
   description: "Improvement of existing code, not introducing new features."


### PR DESCRIPTION
# Proposed Changes

The label is not part of the release drafter and we don't use it in Supervisor. Let's drop it.

## Related Issues
