### PR TITLE
Add support for addon update/install in background

### DIFF
--- a/aiohasupervisor/models/addons.py
+++ b/aiohasupervisor/models/addons.py
@@ -357,6 +357,14 @@ class StoreAddonUpdate(Request):
     """StoreAddonUpdate model."""
 
     backup: bool | None = None
+    background: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StoreAddonInstall(Request):
+    """StoreAddonInstall model."""
+
+    background: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/aiohasupervisor/store.py
+++ b/aiohasupervisor/store.py
@@ -1,11 +1,14 @@
 """Store client for supervisor."""
 
+from typing import Any
+
 from .client import _SupervisorComponentClient
 from .const import ResponseType
 from .models.addons import (
     Repository,
     StoreAddon,
     StoreAddonComplete,
+    StoreAddonInstall,
     StoreAddonsList,
     StoreAddonUpdate,
     StoreAddRepository,
@@ -45,18 +48,34 @@ class StoreClient(_SupervisorComponentClient):
         )
         return result.data
 
-    async def install_addon(self, addon: str) -> None:
+    async def install_addon(
+        self, addon: str, options: StoreAddonInstall | None = None
+    ) -> None:
         """Install an addon."""
-        await self._client.post(f"store/addons/{addon}/install", timeout=None)
+        # Must disable timeout if API call waits for install to complete
+        kwargs: dict[str, Any] = {}
+        if not options or not options.background:
+            kwargs["timeout"] = None
+
+        await self._client.post(
+            f"store/addons/{addon}/install",
+            json=options.to_dict() if options else None,
+            **kwargs,
+        )
 
     async def update_addon(
         self, addon: str, options: StoreAddonUpdate | None = None
     ) -> None:
         """Update an addon to latest version."""
+        # Must disable timeout if API call waits for update to complete
+        kwargs: dict[str, Any] = {}
+        if not options or not options.background:
+            kwargs["timeout"] = None
+
         await self._client.post(
             f"store/addons/{addon}/update",
             json=options.to_dict() if options else None,
-            timeout=None,
+            **kwargs,
         )
 
     async def reload(self) -> None:


### PR DESCRIPTION
# Proposed Changes

Add support for background addon install/update as added in https://github.com/home-assistant/supervisor/pull/6134

As part of this work I realized that background actions should always use the default timeout. Previously something like addon install/update would run without a timeout because that action may take an indefinite amount of time. But when all the docker work is being done in the background it should have the normal timeout.

This second part also applies to backup/restore actions done in the background. We were always calling those APIs with `timeout=None` but that isn't appropriate when the action is being done in the background. Fixed that as well.
