### PR TITLE
Add unsupported reason home_assistant_core_version

### DIFF
--- a/aiohasupervisor/models/resolution.py
+++ b/aiohasupervisor/models/resolution.py
@@ -91,6 +91,7 @@ class UnsupportedReason(StrEnum):
     DNS_SERVER = "dns_server"
     DOCKER_CONFIGURATION = "docker_configuration"
     DOCKER_VERSION = "docker_version"
+    HOME_ASSISTANT_CORE_VERSION = "home_assistant_core_version"
     JOB_CONDITIONS = "job_conditions"
     LXC = "lxc"
     NETWORK_MANAGER = "network_manager"


### PR DESCRIPTION
# Proposed Changes

Add unsupported reason `home_assistant_core_version`

Related to: https://github.com/home-assistant/supervisor/pull/6148

