### PR TITLE
Include Python patch version in CI cache keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -58,7 +58,7 @@ jobs:
           path: ${{ env.PRE_COMMIT_CACHE }}
           lookup-only: true
           key: >
-            ${{ runner.os }}-pre-commit-${{ matrix.python-version }}-
+            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
@@ -89,7 +89,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -102,7 +102,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >
-            ${{ runner.os }}-pre-commit-${{ matrix.python-version }}-
+            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -138,7 +138,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -151,7 +151,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >
-            ${{ runner.os }}-pre-commit-${{ matrix.python-version }}-
+            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -187,7 +187,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -200,7 +200,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           key: >
-            ${{ runner.os }}-pre-commit-${{ matrix.python-version }}-
+            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -279,7 +279,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ matrix.python-version }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -331,7 +331,7 @@ jobs:
         with:
           path: venv
           key: >
-            ${{ runner.os }}-venv-${{ env.DEFAULT_PYTHON }}-
+            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
             ${{ hashFiles('pyproject.toml') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,14 +36,23 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+      - &cache-keys-step
+        name: Generate cache keys
+        id: cache-keys
+        run: |
+          V=${{ steps.python.outputs.python-version }}
+          PYH=${{ hashFiles('pyproject.toml') }}
+          PCH=${{ hashFiles('.pre-commit-config.yaml') }}
+          {
+            echo "venv=${{ runner.os }}-venv-$V-$PYH"
+            echo "precommit=${{ runner.os }}-pre-commit-$V-$PCH"
+          } >> "$GITHUB_OUTPUT"
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -57,9 +66,7 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           lookup-only: true
-          key: >
-            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ steps.cache-keys.outputs.precommit }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
       - name: Install pre-commit dependencies
@@ -83,14 +90,13 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
+      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -101,9 +107,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: >
-            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ steps.cache-keys.outputs.precommit }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -132,14 +136,13 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
+      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -150,9 +153,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: >
-            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ steps.cache-keys.outputs.precommit }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -181,14 +182,13 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
+      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -199,9 +199,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: >
-            ${{ runner.os }}-pre-commit-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ steps.cache-keys.outputs.precommit }}
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -273,14 +271,13 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
+      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -325,14 +322,13 @@ jobs:
         id: python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: >
-            ${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-            ${{ hashFiles('pyproject.toml') }}
+          key: ${{ steps.cache-keys.outputs.venv }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,23 +36,15 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - &cache-keys-step
-        name: Generate cache keys
-        id: cache-keys
-        run: |
-          V=${{ steps.python.outputs.python-version }}
-          PYH=${{ hashFiles('pyproject.toml') }}
-          PCH=${{ hashFiles('.pre-commit-config.yaml') }}
-          {
-            echo "venv=${{ runner.os }}-venv-$V-$PYH"
-            echo "precommit=${{ runner.os }}-pre-commit-$V-$PCH"
-          } >> "$GITHUB_OUTPUT"
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: &venv-key >-
+            ${{ runner.os }}-venv-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('pyproject.toml') }}
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -66,7 +58,10 @@ jobs:
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
           lookup-only: true
-          key: ${{ steps.cache-keys.outputs.precommit }}
+          key: &pre-commit-key >-
+            ${{ runner.os }}-pre-commit-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
       - name: Install pre-commit dependencies
@@ -90,13 +85,12 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
-      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: *venv-key
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -107,7 +101,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: ${{ steps.cache-keys.outputs.precommit }}
+          key: *pre-commit-key
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -136,13 +130,12 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
-      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: *venv-key
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -153,7 +146,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: ${{ steps.cache-keys.outputs.precommit }}
+          key: *pre-commit-key
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -182,13 +175,12 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
-      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: *venv-key
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -199,7 +191,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ${{ env.PRE_COMMIT_CACHE }}
-          key: ${{ steps.cache-keys.outputs.precommit }}
+          key: *pre-commit-key
       - name: Fail job if cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -271,13 +263,12 @@ jobs:
         id: python
         with:
           python-version: ${{ matrix.python-version }}
-      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: *venv-key
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -322,13 +313,12 @@ jobs:
         id: python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - *cache-keys-step
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v5.0.5
         with:
           path: venv
-          key: ${{ steps.cache-keys.outputs.venv }}
+          key: *venv-key
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
The venv and pre-commit caches hold virtualenvs whose python symlink points at `/opt/hostedtoolcache/Python/<patch>/...` When the hosted toolcache bumps patch versions (e.g. 3.13.12 -> 3.13.13), the symlink dangles and every entry point fails with "required file not found". Keying on `steps.python.outputs.python-version` invalidates the cache on any patch bump.

