### PR TITLE
Drop wheel build-system dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0,<82.1", "wheel>=0.40,<0.48"]
+requires = ["setuptools>=68.0,<82.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
# Proposed Changes

Drop the wheel build-system dependency.

This is rarely if ever an actual build dependency with setuptools. This has been cargo culted across the Python ecosystem due to flawed setuptools documentation way back when.

## Related Issues

n/a
