### PR TITLE
Replace pytest-aiohttp with pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "coverage==7.14.1",
     "mypy==2.1.0",
     "pre-commit==4.6.0",
-    "pytest-aiohttp==1.1.1",
+    "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
     "pytest-timeout==2.4.0",
     "pytest==9.0.3",


### PR DESCRIPTION
# Proposed Changes

The test suite uses aioresponses to mock the client and never uses pytest-aiohttp's server/client fixtures. pytest-aiohttp was only pulling in pytest-asyncio transitively, which is what actually runs the async tests via ``asyncio_mode = "auto"``. Depend on pytest-asyncio directly and drop the unused pytest-aiohttp.

