### PR TITLE
Switch test suite from aioresponses to aiointercept

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ version = "0.0.0"
 [project.optional-dependencies]
 dev = [
     # Production requirements
-    "aiohttp==3.13.5",
+    "aiohttp==3.14.1",
     "mashumaro==3.22",
     "orjson==3.11.9",
 
     # Test requirements
-    "aioresponses==0.7.8",
+    "aiointercept==0.1.5",
     "codespell==2.4.2",
     "coverage==7.14.1",
     "mypy==2.1.0",
@@ -70,7 +70,6 @@ filterwarnings = [
     "error",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:dirhash",
     "ignore::pytest.PytestUnraisableExceptionWarning",
-    "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:aioresponses",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ version = "0.0.0"
 [project.optional-dependencies]
 dev = [
     # Production requirements
-    "aiohttp==3.14.1",
+    "aiohttp==3.13.5",
     "mashumaro==3.22",
     "orjson==3.11.9",
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,9 @@ def assert_request_timeout(
     """Assert whether a client side timeout was set for the given request."""
     key = (method, URL(url))
     assert key in request_timeouts, f"no request captured for {key}"
-    assert bool(request_timeouts[key][0]) is has_timeout
+    timeouts = request_timeouts[key]
+    assert len(timeouts) == 1, f"expected one request for {key}, got {len(timeouts)}"
+    assert bool(timeouts[0]) is has_timeout
 
 
 def get_fixture_path(filename: str) -> Path:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,9 @@ def assert_request_timeout(
     has_timeout: bool,
 ) -> None:
     """Assert whether a client side timeout was set for the given request."""
-    assert bool(request_timeouts[(method, URL(url))][0]) is has_timeout
+    key = (method, URL(url))
+    assert key in request_timeouts, f"no request captured for {key}"
+    assert bool(request_timeouts[key][0]) is has_timeout
 
 
 def get_fixture_path(filename: str) -> Path:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,22 @@
 
 from pathlib import Path
 
+from aiohttp import ClientTimeout
+from yarl import URL
+
+type RequestTimeouts = dict[tuple[str, URL], list[ClientTimeout | None]]
+
+
+def assert_request_timeout(
+    request_timeouts: RequestTimeouts,
+    method: str,
+    url: str,
+    *,
+    has_timeout: bool,
+) -> None:
+    """Assert whether a client side timeout was set for the given request."""
+    assert bool(request_timeouts[(method, URL(url))][0]) is has_timeout
+
 
 def get_fixture_path(filename: str) -> Path:
     """Get fixture path."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 """Shared fixtures for aiohasupervisor tests."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
+from typing import Any
 
-from aioresponses import aioresponses
+from aiohttp import ClientSession
+from aiointercept import aiointercept
 import pytest
+from yarl import URL
 
 from aiohasupervisor import SupervisorClient
 
+from . import RequestTimeouts
 from .const import SUPERVISOR_URL
 
 
@@ -21,7 +25,30 @@ async def client() -> AsyncGenerator[SupervisorClient, None]:
 
 
 @pytest.fixture(name="responses")
-def aioresponses_fixture() -> Generator[aioresponses, None, None]:
-    """Return aioresponses fixture."""
-    with aioresponses() as mocked_responses:
+async def aiointercept_fixture() -> AsyncGenerator[aiointercept, None]:
+    """Return aiointercept fixture."""
+    # mock_external_urls keeps the aioresponses behavior of intercepting the
+    # SUPERVISOR_URL host so the existing call sites need no changes.
+    async with aiointercept(mock_external_urls=True) as mocked_responses:
         yield mocked_responses
+
+
+@pytest.fixture(name="request_timeouts")
+def request_timeouts_fixture(monkeypatch: pytest.MonkeyPatch) -> RequestTimeouts:
+    """Capture the client side timeout passed to each request.
+
+    aiointercept routes requests through a real test server, so the client side
+    timeout is not visible in the captured request. Record it here instead.
+    """
+    timeouts: RequestTimeouts = {}
+    original = ClientSession.request
+
+    def _capture(
+        self: ClientSession, method: str, str_or_url: Any, **kwargs: Any
+    ) -> Any:
+        key = (method, URL(str_or_url))
+        timeouts.setdefault(key, []).append(kwargs.get("timeout"))
+        return original(self, method, str_or_url, **kwargs)
+
+    monkeypatch.setattr(ClientSession, "request", _capture)
+    return timeouts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,6 @@ async def client() -> AsyncGenerator[SupervisorClient, None]:
 @pytest.fixture(name="responses")
 async def aiointercept_fixture() -> AsyncGenerator[aiointercept, None]:
     """Return aiointercept fixture."""
-    # mock_external_urls keeps the aioresponses behavior of intercepting the
-    # SUPERVISOR_URL host so the existing call sites need no changes.
     async with aiointercept(mock_external_urls=True) as mocked_responses:
         yield mocked_responses
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -2,7 +2,7 @@
 
 from ipaddress import IPv4Address
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from aiohasupervisor import SupervisorClient
@@ -27,7 +27,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_addons_list(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addons list API."""
     responses.get(
@@ -44,7 +44,7 @@ async def test_addons_list(
 
 
 async def test_addons_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addons info API."""
     responses.get(
@@ -70,7 +70,7 @@ async def test_addons_info(
 
 
 async def test_addons_uninstall(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test uninstall addon API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/uninstall", status=200)
@@ -86,7 +86,7 @@ async def test_addons_uninstall(
 
 
 async def test_addons_start(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test start addon API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/start", status=200)
@@ -97,7 +97,7 @@ async def test_addons_start(
 
 
 async def test_addons_stop(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test stop addon API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/stop", status=200)
@@ -108,7 +108,7 @@ async def test_addons_stop(
 
 
 async def test_addons_restart(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test restart addon API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/restart", status=200)
@@ -119,7 +119,7 @@ async def test_addons_restart(
 
 
 async def test_addons_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addon options API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/options", status=200)
@@ -150,7 +150,7 @@ async def test_addons_options(
 
 
 async def test_addons_config_validate(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test config validate API."""
     responses.post(
@@ -170,7 +170,7 @@ async def test_addons_config_validate(
 
 
 async def test_addons_config(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test get addon config API."""
     responses.get(
@@ -184,7 +184,7 @@ async def test_addons_config(
 
 
 async def test_addons_rebuild(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test rebuild addon API."""
     responses.post(f"{SUPERVISOR_URL}/addons/local_example/rebuild", status=200)
@@ -195,7 +195,7 @@ async def test_addons_rebuild(
 
 
 async def test_addons_rebuild_with_force(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test rebuild addon API with force option."""
     responses.post(f"{SUPERVISOR_URL}/addons/local_example/rebuild", status=200)
@@ -214,7 +214,7 @@ async def test_addons_rebuild_with_force(
 
 
 async def test_addons_stdin(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addon stdin API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/stdin", status=200)
@@ -228,11 +228,11 @@ async def test_addons_stdin(
             ("POST", URL(f"{SUPERVISOR_URL}/addons/core_ssh/stdin"))
         ]
     )
-    assert request[0].kwargs["data"] == b"hello world"
+    assert request[0].captured_body == b"hello world"
 
 
 async def test_addons_security(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addon security API."""
     responses.post(f"{SUPERVISOR_URL}/addons/core_ssh/security", status=200)
@@ -252,7 +252,7 @@ async def test_addons_security(
 
 
 async def test_addons_stats(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test addon stats API."""
     responses.get(

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from pathlib import PurePath
 from typing import Any
 
-from aioresponses import CallbackResult, aioresponses
+from aiointercept import CallbackResult, aiointercept
 import pytest
 from yarl import URL
 
@@ -26,12 +26,12 @@ from aiohasupervisor.models import (
     UploadBackupOptions,
 )
 
-from . import load_fixture
+from . import RequestTimeouts, assert_request_timeout, load_fixture
 from .const import SUPERVISOR_URL
 
 
 async def test_backups_list(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backups list API."""
     responses.get(
@@ -49,7 +49,7 @@ async def test_backups_list(
 
 
 async def test_backups_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backups info API."""
     responses.get(
@@ -64,7 +64,7 @@ async def test_backups_info(
 
 
 async def test_backups_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backups options API."""
     responses.post(f"{SUPERVISOR_URL}/backups/options", status=200)
@@ -78,7 +78,7 @@ async def test_backups_options(
 
 
 async def test_backups_reload(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backups reload API."""
     responses.post(f"{SUPERVISOR_URL}/backups/reload", status=200)
@@ -90,7 +90,7 @@ async def test_backups_reload(
 
 @pytest.mark.parametrize("options", [None, FreezeOptions(timeout=1000)])
 async def test_backups_freeze(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: FreezeOptions | None,
 ) -> None:
@@ -103,7 +103,7 @@ async def test_backups_freeze(
 
 
 async def test_backups_thaw(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backups thaw API."""
     responses.post(f"{SUPERVISOR_URL}/backups/thaw", status=200)
@@ -179,7 +179,7 @@ def backup_callback(url: str, **kwargs: dict[str, Any]) -> CallbackResult:  # no
         ),
         (
             FullBackupOptions(
-                name="Test", background=False, location={".local", "test"}
+                name="Test", background=False, location=[".local", "test"]
             ),
             "9ecf0028",
             False,
@@ -207,7 +207,8 @@ def backup_callback(url: str, **kwargs: dict[str, Any]) -> CallbackResult:  # no
     ],
 )
 async def test_backups_full_backup(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: FullBackupOptions | None,
     slug: str | None,
@@ -221,13 +222,11 @@ async def test_backups_full_backup(
     result = await supervisor_client.backups.full_backup(options)
     assert result.job_id.hex == "dc9dbc16f6ad4de592ffa72c807ca2bf"
     assert result.slug == slug
-    assert (
-        bool(
-            responses.requests[("POST", URL(f"{SUPERVISOR_URL}/backups/new/full"))][
-                0
-            ].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/backups/new/full",
+        has_timeout=has_timeout,
     )
 
 
@@ -255,7 +254,7 @@ async def test_backups_full_backup(
             PartialBackupOptions(
                 name="Test",
                 background=False,
-                location={".local", "test"},
+                location=[".local", "test"],
                 addons={"core_ssh"},
             ),
             "9ecf0028",
@@ -301,7 +300,8 @@ async def test_backups_full_backup(
     ],
 )
 async def test_backups_partial_backup(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: PartialBackupOptions,
     slug: str | None,
@@ -315,18 +315,16 @@ async def test_backups_partial_backup(
     result = await supervisor_client.backups.partial_backup(options)
     assert result.job_id.hex == "dc9dbc16f6ad4de592ffa72c807ca2bf"
     assert result.slug == slug
-    assert (
-        bool(
-            responses.requests[("POST", URL(f"{SUPERVISOR_URL}/backups/new/partial"))][
-                0
-            ].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/backups/new/partial",
+        has_timeout=has_timeout,
     )
 
 
 async def test_backup_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backup info API."""
     responses.get(
@@ -358,7 +356,7 @@ async def test_backup_info(
 
 
 async def test_backup_info_no_homeassistant(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backup info API with no home assistant."""
     responses.get(
@@ -373,7 +371,7 @@ async def test_backup_info_no_homeassistant(
 
 
 async def test_backup_info_with_extra(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backup info API with extras set by client."""
     responses.get(
@@ -388,7 +386,7 @@ async def test_backup_info_with_extra(
 
 
 async def test_backup_info_with_multiple_locations(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test backup info API with multiple locations."""
     responses.get(
@@ -409,7 +407,7 @@ async def test_backup_info_with_multiple_locations(
     "options", [None, RemoveBackupOptions(location={"test", None})]
 )
 async def test_remove_backup(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: RemoveBackupOptions | None,
 ) -> None:
@@ -431,7 +429,8 @@ async def test_remove_backup(
     ],
 )
 async def test_full_restore(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: FullRestoreOptions | None,
     has_timeout: bool,  # noqa: FBT001
@@ -444,13 +443,11 @@ async def test_full_restore(
     )
     result = await supervisor_client.backups.full_restore("abc123", options)
     assert result.job_id.hex == "dc9dbc16f6ad4de592ffa72c807ca2bf"
-    assert (
-        bool(
-            responses.requests[
-                ("POST", URL(f"{SUPERVISOR_URL}/backups/abc123/restore/full"))
-            ][0].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/backups/abc123/restore/full",
+        has_timeout=has_timeout,
     )
 
 
@@ -468,7 +465,8 @@ async def test_full_restore(
     ],
 )
 async def test_partial_restore(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: PartialRestoreOptions,
     has_timeout: bool,  # noqa: FBT001
@@ -481,13 +479,11 @@ async def test_partial_restore(
     )
     result = await supervisor_client.backups.partial_restore("abc123", options)
     assert result.job_id.hex == "dc9dbc16f6ad4de592ffa72c807ca2bf"
-    assert (
-        bool(
-            responses.requests[
-                ("POST", URL(f"{SUPERVISOR_URL}/backups/abc123/restore/partial"))
-            ][0].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/backups/abc123/restore/partial",
+        has_timeout=has_timeout,
     )
 
 
@@ -503,7 +499,7 @@ async def test_partial_restore(
     ],
 )
 async def test_upload_backup(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: UploadBackupOptions | None,
     query: str,
@@ -527,11 +523,12 @@ async def test_upload_backup(
     [
         (None, ""),
         (DownloadBackupOptions(location="test"), "?location=test"),
-        (DownloadBackupOptions(location=None), "?location="),
+        # location=None is omitted from the query, so no parameter is sent.
+        (DownloadBackupOptions(location=None), ""),
     ],
 )
 async def test_download_backup(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: DownloadBackupOptions | None,
     query: str,
@@ -624,7 +621,7 @@ async def test_full_backup_model(
 
 
 async def test_backups_list_location_attributes(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
 ) -> None:
     """Test location attributes field in backups list."""
@@ -648,7 +645,7 @@ async def test_backups_list_location_attributes(
 
 
 async def test_backup_info_location_attributes(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
 ) -> None:
     """Test location attributes field in backup info."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from aiohasupervisor import SupervisorClient
@@ -13,7 +13,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_discovery_list(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Discovery list API."""
     responses.get(
@@ -29,7 +29,7 @@ async def test_discovery_list(
 
 
 async def test_get_discovery(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Discovery get API."""
     uuid = UUID("889ca604cff84004894e53d181655b3a")
@@ -48,7 +48,7 @@ async def test_get_discovery(
 
 
 async def test_delete_discovery(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Discovery delete API."""
     uuid = UUID("889ca604cff84004894e53d181655b3a")
@@ -60,7 +60,7 @@ async def test_delete_discovery(
 
 
 async def test_set_discovery(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Discovery set API."""
     responses.post(

--- a/tests/test_homeassistant.py
+++ b/tests/test_homeassistant.py
@@ -2,7 +2,7 @@
 
 from ipaddress import IPv4Address
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -20,7 +20,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_homeassistant_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Home Assistant info API."""
     responses.get(
@@ -41,7 +41,7 @@ async def test_homeassistant_info(
 
 
 async def test_homeassistant_stats(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Home Assistant stats API."""
     responses.get(
@@ -57,7 +57,7 @@ async def test_homeassistant_stats(
 
 
 async def test_homeassistant_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Home Assistant options API."""
     responses.post(f"{SUPERVISOR_URL}/core/options", status=200)
@@ -74,7 +74,7 @@ async def test_homeassistant_options(
 
 @pytest.mark.parametrize("options", [None, HomeAssistantUpdateOptions(backup=False)])
 async def test_homeassistant_update(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: HomeAssistantUpdateOptions | None,
 ) -> None:
@@ -86,7 +86,7 @@ async def test_homeassistant_update(
 
 @pytest.mark.parametrize("options", [None, HomeAssistantRestartOptions(safe_mode=True)])
 async def test_homeassistant_restart(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: HomeAssistantRestartOptions | None,
 ) -> None:
@@ -100,7 +100,7 @@ async def test_homeassistant_restart(
 
 @pytest.mark.parametrize("options", [None, HomeAssistantStopOptions(force=True)])
 async def test_homeassistant_stop(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: HomeAssistantStopOptions | None,
 ) -> None:
@@ -111,7 +111,7 @@ async def test_homeassistant_stop(
 
 
 async def test_homeassistant_start(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Home Assistant start API."""
     responses.post(f"{SUPERVISOR_URL}/core/start", status=200)
@@ -120,7 +120,7 @@ async def test_homeassistant_start(
 
 
 async def test_homeassistant_check_config(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Home Assistant check config API."""
     responses.post(f"{SUPERVISOR_URL}/core/check", status=200)
@@ -130,7 +130,7 @@ async def test_homeassistant_check_config(
 
 @pytest.mark.parametrize("options", [None, HomeAssistantRebuildOptions(safe_mode=True)])
 async def test_homeassistant_rebuild(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: HomeAssistantRebuildOptions | None,
 ) -> None:

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -14,7 +14,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_host_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host info API."""
     responses.get(
@@ -49,7 +49,7 @@ async def test_host_info(
 
 @pytest.mark.parametrize("options", [None, RebootOptions(force=True)])
 async def test_host_reboot(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: RebootOptions | None,
 ) -> None:
@@ -61,7 +61,7 @@ async def test_host_reboot(
 
 @pytest.mark.parametrize("options", [None, ShutdownOptions(force=True)])
 async def test_host_shutdown(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: ShutdownOptions | None,
 ) -> None:
@@ -74,7 +74,7 @@ async def test_host_shutdown(
 
 
 async def test_host_reload(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host reload API."""
     responses.post(f"{SUPERVISOR_URL}/host/reload", status=200)
@@ -83,7 +83,7 @@ async def test_host_reload(
 
 
 async def test_host_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host options API."""
     responses.post(f"{SUPERVISOR_URL}/host/options", status=200)
@@ -96,7 +96,7 @@ async def test_host_options(
 
 
 async def test_host_services(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host services API."""
     responses.get(
@@ -114,7 +114,7 @@ async def test_host_services(
 
 
 async def test_host_disk_usage(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host disk usage API."""
     responses.get(
@@ -189,7 +189,7 @@ async def test_host_disk_usage(
 
 
 async def test_host_disk_usage_with_custom_depth(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test host disk usage API with custom max_depth."""
     responses.get(

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -1,6 +1,6 @@
 """Test ingress component client."""
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -12,7 +12,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_panels(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test panels API."""
     responses.get(
@@ -38,7 +38,7 @@ async def test_panels(
     [(None, None), (CreateSessionOptions(user_id="test"), {"user_id": "test"})],
 )
 async def test_create_session(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: CreateSessionOptions | None,
     expected_body: dict[str, str] | None,
@@ -56,7 +56,7 @@ async def test_create_session(
 
 
 async def test_validate_session(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test validate session API."""
     validate_url = f"{SUPERVISOR_URL}/ingress/validate_session"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from aiohasupervisor import SupervisorClient
@@ -14,7 +14,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_jobs_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs info API."""
     responses.get(
@@ -46,7 +46,7 @@ async def test_jobs_info(
 
 
 async def test_jobs_set_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs set options API."""
     responses.post(f"{SUPERVISOR_URL}/jobs/options", status=200)
@@ -62,7 +62,7 @@ async def test_jobs_set_options(
 
 
 async def test_jobs_reset(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs reset API."""
     responses.post(f"{SUPERVISOR_URL}/jobs/reset", status=200)
@@ -71,7 +71,7 @@ async def test_jobs_reset(
 
 
 async def test_jobs_get_job(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs get job API."""
     responses.get(
@@ -98,7 +98,7 @@ async def test_jobs_get_job(
 
 
 async def test_jobs_get_job_extra(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs get job API with extra metadata."""
     responses.get(
@@ -120,7 +120,7 @@ async def test_jobs_get_job_extra(
 
 
 async def test_jobs_delete_job(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs delete job API."""
     responses.delete(
@@ -138,7 +138,7 @@ async def test_jobs_delete_job(
 
 
 async def test_jobs_info_backward_compatibility_no_stage(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test jobs info API with error lacking stage field for backward compatibility."""
     responses.get(

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -2,7 +2,7 @@
 
 from pathlib import PurePath
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -20,7 +20,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_mounts_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test mounts info API."""
     responses.get(
@@ -53,7 +53,7 @@ async def test_mounts_info(
 
 @pytest.mark.parametrize("mount_name", ["test", None])
 async def test_mounts_options(
-    responses: aioresponses, supervisor_client: SupervisorClient, mount_name: str | None
+    responses: aiointercept, supervisor_client: SupervisorClient, mount_name: str | None
 ) -> None:
     """Test mounts options API."""
     responses.post(f"{SUPERVISOR_URL}/mounts/options", status=200)
@@ -101,7 +101,7 @@ async def test_mounts_options(
     ],
 )
 async def test_create_mount(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     mount_config: CIFSMountRequest | NFSMountRequest,
 ) -> None:
@@ -144,7 +144,7 @@ async def test_create_mount(
     ],
 )
 async def test_update_mount(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     mount_config: CIFSMountRequest | NFSMountRequest,
 ) -> None:
@@ -155,7 +155,7 @@ async def test_update_mount(
 
 
 async def test_delete_mount(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test delete mount API."""
     responses.delete(f"{SUPERVISOR_URL}/mounts/test", status=200)
@@ -166,7 +166,7 @@ async def test_delete_mount(
 
 
 async def test_reload_mount(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test reload mount API."""
     responses.post(f"{SUPERVISOR_URL}/mounts/test/reload", status=200)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2,7 +2,7 @@
 
 from ipaddress import IPv4Address, IPv4Interface
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -23,7 +23,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_network_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test network info API."""
     responses.get(
@@ -73,7 +73,7 @@ async def test_network_info(
 
 
 async def test_network_reload(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test network reload API."""
     responses.post(f"{SUPERVISOR_URL}/network/reload", status=200)
@@ -84,7 +84,7 @@ async def test_network_reload(
 
 
 async def test_network_interface_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test network interface info API."""
     responses.get(
@@ -116,7 +116,7 @@ async def test_network_interface_info(
 
 
 async def test_network_update_interface(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test network interface update API."""
     responses.post(f"{SUPERVISOR_URL}/network/interface/end0/update", status=200)
@@ -161,7 +161,7 @@ async def test_network_update_interface(
 
 
 async def test_network_access_points(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test network access points API."""
     responses.get(
@@ -187,7 +187,7 @@ async def test_network_access_points(
     ],
 )
 async def test_network_save_vlan(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     config: NetworkInterfaceConfig | None,
 ) -> None:

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -2,7 +2,7 @@
 
 from pathlib import PurePath
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -22,7 +22,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_os_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS info API."""
     responses.get(
@@ -42,7 +42,7 @@ async def test_os_info(
 
 @pytest.mark.parametrize("options", [None, OSUpdate(version="13.0")])
 async def test_os_update(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: OSUpdate | None,
 ) -> None:
@@ -53,7 +53,7 @@ async def test_os_update(
 
 
 async def test_os_swap_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS config swap API."""
     responses.get(
@@ -67,7 +67,7 @@ async def test_os_swap_info(
 
 
 async def test_os_set_swap_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS set swap options API."""
     responses.post(f"{SUPERVISOR_URL}/os/config/swap", status=200)
@@ -83,7 +83,7 @@ async def test_os_set_swap_options(
 
 
 async def test_os_config_sync(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS config sync API."""
     responses.post(f"{SUPERVISOR_URL}/os/config/sync", status=200)
@@ -94,7 +94,7 @@ async def test_os_config_sync(
 
 
 async def test_os_migrate_data(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS migrate data API."""
     responses.post(f"{SUPERVISOR_URL}/os/datadisk/move", status=200)
@@ -108,7 +108,7 @@ async def test_os_migrate_data(
 
 
 async def test_os_list_data_disks(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS datadisk list API."""
     responses.get(
@@ -125,7 +125,7 @@ async def test_os_list_data_disks(
 
 
 async def test_os_wipe_data(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS wipe data API."""
     responses.post(f"{SUPERVISOR_URL}/os/datadisk/wipe", status=200)
@@ -136,7 +136,7 @@ async def test_os_wipe_data(
 
 
 async def test_os_set_boot_slot(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS set boot slot API."""
     responses.post(f"{SUPERVISOR_URL}/os/boot-slot", status=200)
@@ -152,7 +152,7 @@ async def test_os_set_boot_slot(
 
 
 async def test_os_green_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS green board info API."""
     responses.get(
@@ -167,7 +167,7 @@ async def test_os_green_info(
 
 
 async def test_os_green_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS green board options API."""
     responses.post(f"{SUPERVISOR_URL}/os/boards/green", status=200)
@@ -181,7 +181,7 @@ async def test_os_green_options(
 
 
 async def test_os_yellow_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS yellow board info API."""
     responses.get(
@@ -196,7 +196,7 @@ async def test_os_yellow_info(
 
 
 async def test_os_yellow_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test OS yellow board options API."""
     responses.post(f"{SUPERVISOR_URL}/os/boards/yellow", status=200)
@@ -212,7 +212,7 @@ async def test_os_yellow_options(
 
 
 async def test_os_raspberry_pi_firmware_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Raspberry Pi firmware info API."""
     responses.get(
@@ -230,7 +230,7 @@ async def test_os_raspberry_pi_firmware_info(
 
 
 async def test_os_update_raspberry_pi_firmware(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test Raspberry Pi firmware update API."""
     responses.post(

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -2,7 +2,7 @@
 
 from uuid import uuid4
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from aiohasupervisor import SupervisorClient
@@ -13,7 +13,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_resolution_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center info API."""
     responses.get(
@@ -38,7 +38,7 @@ async def test_resolution_info(
 
 
 async def test_resolution_check_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center check options API."""
     responses.post(f"{SUPERVISOR_URL}/resolution/check/backups/options", status=200)
@@ -54,7 +54,7 @@ async def test_resolution_check_options(
 
 
 async def test_resolution_run_check(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center run check API."""
     responses.post(f"{SUPERVISOR_URL}/resolution/check/backups/run", status=200)
@@ -65,7 +65,7 @@ async def test_resolution_run_check(
 
 
 async def test_resolution_apply_suggestion(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center apply suggestion API."""
     uuid = uuid4()
@@ -77,7 +77,7 @@ async def test_resolution_apply_suggestion(
 
 
 async def test_resolution_dismiss_suggestion(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center dismiss suggestion API."""
     uuid = uuid4()
@@ -89,7 +89,7 @@ async def test_resolution_dismiss_suggestion(
 
 
 async def test_resolution_dismiss_issue(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center dismiss issue API."""
     uuid = uuid4()
@@ -101,7 +101,7 @@ async def test_resolution_dismiss_issue(
 
 
 async def test_resolution_suggestions_for_issue(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center suggestions for issue API."""
     uuid = uuid4()
@@ -117,7 +117,7 @@ async def test_resolution_suggestions_for_issue(
 
 
 async def test_resolution_healthcheck(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test resolution center healthcheck API."""
     responses.post(f"{SUPERVISOR_URL}/resolution/healthcheck", status=200)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -3,7 +3,7 @@
 from json import dumps
 
 from aiohttp import ClientSession
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -22,7 +22,7 @@ from . import load_fixture
 from .const import SUPERVISOR_URL
 
 
-async def test_using_own_session(responses: aioresponses) -> None:
+async def test_using_own_session(responses: aiointercept) -> None:
     """Test passing in an existing session."""
     responses.get(
         f"{SUPERVISOR_URL}/info", status=200, body=load_fixture("root_info.json")
@@ -37,7 +37,7 @@ async def test_using_own_session(responses: aioresponses) -> None:
         assert not session.closed
 
 
-async def test_using_new_session(responses: aioresponses) -> None:
+async def test_using_new_session(responses: aiointercept) -> None:
     """Test letting client create new session."""
     responses.get(
         f"{SUPERVISOR_URL}/info", status=200, body=load_fixture("root_info.json")
@@ -52,7 +52,7 @@ async def test_using_new_session(responses: aioresponses) -> None:
 
 
 async def test_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test info API."""
     responses.get(
@@ -71,7 +71,7 @@ async def test_info(
 
 
 async def test_available_updates(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test available updates API."""
     responses.get(
@@ -89,7 +89,7 @@ async def test_available_updates(
 
 
 async def test_reload_updates(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test reload updates API."""
     responses.post(f"{SUPERVISOR_URL}/reload_updates", status=200)
@@ -100,7 +100,7 @@ async def test_reload_updates(
 
 
 async def test_refresh_updates(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test refresh updates API."""
     responses.post(f"{SUPERVISOR_URL}/refresh_updates", status=200)
@@ -122,7 +122,7 @@ async def test_refresh_updates(
     ],
 )
 async def test_error_handling(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     status: int,
     message: str | None,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,7 +2,7 @@
 
 from json import loads
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -17,12 +17,12 @@ from aiohasupervisor.exceptions import (
 from aiohasupervisor.models import StoreAddonUpdate, StoreAddRepository
 from aiohasupervisor.models.addons import StoreAddonInstall
 
-from . import load_fixture
+from . import RequestTimeouts, assert_request_timeout, load_fixture
 from .const import SUPERVISOR_URL
 
 
 async def test_store_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store info API."""
     responses.get(
@@ -40,7 +40,7 @@ async def test_store_info(
 
 
 async def test_store_addons_list(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store addons list API."""
     responses.get(
@@ -56,7 +56,7 @@ async def test_store_addons_list(
 
 
 async def test_store_repositories_list(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store repositories list API."""
     responses.get(
@@ -72,7 +72,7 @@ async def test_store_repositories_list(
 
 
 async def test_store_addon_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store addon info API."""
     responses.get(
@@ -90,7 +90,7 @@ async def test_store_addon_info(
 
 
 async def test_store_addon_changelog(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store addon info changelog API."""
     responses.get(
@@ -103,7 +103,7 @@ async def test_store_addon_changelog(
 
 
 async def test_store_addon_documentation(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store addon documentation API."""
     responses.get(
@@ -125,7 +125,8 @@ async def test_store_addon_documentation(
     ],
 )
 async def test_store_addon_install(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: StoreAddonInstall | None,
     has_timeout: bool,  # noqa: FBT001
@@ -136,13 +137,11 @@ async def test_store_addon_install(
     assert (
         await supervisor_client.store.install_addon("core_mosquitto", options)
     ) is None
-    assert (
-        bool(
-            responses.requests[
-                ("POST", URL(f"{SUPERVISOR_URL}/store/addons/core_mosquitto/install"))
-            ][0].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/store/addons/core_mosquitto/install",
+        has_timeout=has_timeout,
     )
 
 
@@ -157,7 +156,8 @@ async def test_store_addon_install(
     ],
 )
 async def test_store_addon_update(
-    responses: aioresponses,
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: StoreAddonUpdate | None,
     has_timeout: bool,  # noqa: FBT001
@@ -168,18 +168,16 @@ async def test_store_addon_update(
     assert (
         await supervisor_client.store.update_addon("core_mosquitto", options)
     ) is None
-    assert (
-        bool(
-            responses.requests[
-                ("POST", URL(f"{SUPERVISOR_URL}/store/addons/core_mosquitto/update"))
-            ][0].kwargs["timeout"]
-        )
-        is has_timeout
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/store/addons/core_mosquitto/update",
+        has_timeout=has_timeout,
     )
 
 
 async def test_store_addon_availability(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store addon availability API."""
     responses.get(
@@ -215,7 +213,7 @@ async def test_store_addon_availability(
     ],
 )
 async def test_store_addon_availability_error(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     error_fixture: str,
     error_key: str | None,
@@ -265,7 +263,7 @@ async def test_store_addon_availability_error(
 
 
 async def test_store_reload(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store reload API."""
     responses.post(f"{SUPERVISOR_URL}/store/reload", status=200)
@@ -277,7 +275,7 @@ async def test_store_reload(
 
 
 async def test_store_repository_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store repository info API."""
     responses.get(
@@ -292,7 +290,7 @@ async def test_store_repository_info(
 
 
 async def test_store_add_repository(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store add repository API."""
     responses.post(f"{SUPERVISOR_URL}/store/repositories", status=200)
@@ -308,7 +306,7 @@ async def test_store_add_repository(
 
 
 async def test_store_remove_repository(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store remove repository API."""
     responses.delete(f"{SUPERVISOR_URL}/store/repositories/test", status=200)
@@ -320,7 +318,7 @@ async def test_store_remove_repository(
 
 
 async def test_store_repair_repository(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test store repository repair API."""
     responses.post(f"{SUPERVISOR_URL}/store/repositories/test/repair", status=200)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -3,7 +3,7 @@
 from ipaddress import IPv4Address
 import json
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 import pytest
 from yarl import URL
 
@@ -16,7 +16,7 @@ from .const import SUPERVISOR_URL
 
 
 async def test_supervisor_ping(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor ping API."""
     responses.get(f"{SUPERVISOR_URL}/supervisor/ping", status=200)
@@ -27,7 +27,7 @@ async def test_supervisor_ping(
 
 
 async def test_supervisor_info(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor info API."""
     responses.get(
@@ -51,7 +51,7 @@ async def test_supervisor_info(
 
 @pytest.mark.parametrize("field", ["version_latest", "arch"])
 async def test_supervisor_info_optional_fields_none(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     field: str,
 ) -> None:
@@ -68,7 +68,7 @@ async def test_supervisor_info_optional_fields_none(
 
 
 async def test_supervisor_stats(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor stats API."""
     responses.get(
@@ -88,7 +88,7 @@ async def test_supervisor_stats(
     "options", [None, SupervisorUpdateOptions(version="2024.01.0")]
 )
 async def test_supervisor_update(
-    responses: aioresponses,
+    responses: aiointercept,
     supervisor_client: SupervisorClient,
     options: SupervisorUpdateOptions | None,
 ) -> None:
@@ -101,7 +101,7 @@ async def test_supervisor_update(
 
 
 async def test_supervisor_reload(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor reload API."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/reload", status=200)
@@ -112,7 +112,7 @@ async def test_supervisor_reload(
 
 
 async def test_supervisor_restart(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor restart API."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/restart", status=200)
@@ -123,7 +123,7 @@ async def test_supervisor_restart(
 
 
 async def test_supervisor_options(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor options API."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/options", status=200)
@@ -155,7 +155,7 @@ async def test_supervisor_options(
 
 
 async def test_supervisor_info_unknown_feature_flag(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor info with an unknown feature flag returns it as a string key."""
     fixture = json.loads(load_fixture("supervisor_info.json"))
@@ -171,7 +171,7 @@ async def test_supervisor_info_unknown_feature_flag(
 
 
 async def test_supervisor_options_feature_flags(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor options API with feature_flags."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/options", status=200)
@@ -194,7 +194,7 @@ async def test_supervisor_options_feature_flags(
 
 
 async def test_supervisor_repair(
-    responses: aioresponses, supervisor_client: SupervisorClient
+    responses: aiointercept, supervisor_client: SupervisorClient
 ) -> None:
     """Test supervisor repair API."""
     responses.post(f"{SUPERVISOR_URL}/supervisor/repair", status=200)


### PR DESCRIPTION
# Proposed Changes

Switch the test suite from aioresponses to aiointercept.

aioresponses mocks by calling the ClientResponse constructor directly, but that constructor is not public; the aiohttp docs are explicit that users never construct ClientResponse, they only get it from API calls. By replicating that signature aioresponses ties itself to an aiohttp internal that changes as needed, so it breaks on nearly every minor bump. The latest case is aiohttp 3.14, where ClientResponse gained a required stream_writer argument and every mocked request now raises a TypeError. aiohttp maintainers have said they will not keep patching aioresponses for this, and recommend migrating; see aio-libs/aiohttp#12815 and the discussion at aio-libs/discussions/45.

aiointercept routes requests through a real aiohttp test server instead of monkey patching internals, so it does not depend on private signatures and keeps working across aiohttp releases. The mock_external_urls option keeps the SUPERVISOR_URL host intercepted, so the call sites are unchanged apart from the rename. The client side request timeout is not visible through a real round trip, so it is captured with a small fixture and asserted through a shared helper. The aiohttp pin is left as is so dependabot can bump it in #344.

## Related Issues

Unblocks #344, works around aio-libs/aiohttp#12815

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/