### PR TITLE
Add reference_extra field and APP_PORT_CONFLICT/CLEAR_PORT_CONFIG types

### DIFF
--- a/aiohasupervisor/models/resolution.py
+++ b/aiohasupervisor/models/resolution.py
@@ -19,6 +19,7 @@ class SuggestionType(StrEnum):
 
     ADOPT_DATA_DISK = "adopt_data_disk"
     CLEAR_FULL_BACKUP = "clear_full_backup"
+    CLEAR_PORT_CONFIG = "clear_port_config"
     CREATE_FULL_BACKUP = "create_full_backup"
     DISABLE_BOOT = "disable_boot"
     ENABLE_NTP = "enable_ntp"
@@ -44,6 +45,7 @@ class IssueType(StrEnum):
     in this list parsed as strings on older versions of the client.
     """
 
+    APP_PORT_CONFLICT = "app_port_conflict"
     BOOT_FAIL = "boot_fail"
     CORRUPT_DOCKER = "corrupt_docker"
     CORRUPT_REPOSITORY = "corrupt_repository"
@@ -176,6 +178,7 @@ class Suggestion(ResponseData):
     reference: str | None
     uuid: UUID
     auto: bool
+    reference_extra: dict | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -186,6 +189,7 @@ class Issue(ResponseData):
     context: ContextType
     reference: str | None
     uuid: UUID
+    reference_extra: dict | None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/fixtures/resolution_info.json
+++ b/tests/fixtures/resolution_info.json
@@ -9,7 +9,8 @@
         "context": "system",
         "reference": null,
         "uuid": "f87d3556f02c4004a47111c072c76fac",
-        "auto": false
+        "auto": false,
+        "reference_extra": null
       }
     ],
     "issues": [
@@ -17,7 +18,8 @@
         "type": "no_current_backup",
         "context": "system",
         "reference": null,
-        "uuid": "7f0eac2b61c9456dab6970507a276c36"
+        "uuid": "7f0eac2b61c9456dab6970507a276c36",
+        "reference_extra": null
       }
     ],
     "checks": [

--- a/tests/fixtures/resolution_suggestions_for_issue.json
+++ b/tests/fixtures/resolution_suggestions_for_issue.json
@@ -7,7 +7,8 @@
         "context": "system",
         "reference": null,
         "uuid": "f87d3556f02c4004a47111c072c76fac",
-        "auto": false
+        "auto": false,
+        "reference_extra": null
       }
     ]
   }

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -27,11 +27,13 @@ async def test_resolution_info(
     assert info.issues[0].context == "system"
     assert info.issues[0].type == "no_current_backup"
     assert info.issues[0].reference is None
+    assert info.issues[0].reference_extra is None
     assert info.issues[0].uuid.hex == "7f0eac2b61c9456dab6970507a276c36"
     assert info.suggestions[0].auto is False
     assert info.suggestions[0].context == "system"
     assert info.suggestions[0].type == "create_full_backup"
     assert info.suggestions[0].reference is None
+    assert info.suggestions[0].reference_extra is None
     assert info.suggestions[0].uuid.hex == "f87d3556f02c4004a47111c072c76fac"
     assert info.unhealthy == ["supervisor"]
     assert info.unsupported == []


### PR DESCRIPTION
## Changes

Updates the client library to reflect the API changes introduced in [home-assistant/supervisor#6916](https://github.com/home-assistant/supervisor/pull/6916).

- Add `reference_extra: dict | None` field to `Issue` and `Suggestion` models
- Add `IssueType.APP_PORT_CONFLICT`
- Add `SuggestionType.CLEAR_PORT_CONFIG`
- Update test fixtures and assertions accordingly

## Related

- Supervisor PR: home-assistant/supervisor#6916