### PR TITLE
Add fsck and systemd unit failure enum values to resolution models

### DIFF
--- a/aiohasupervisor/models/resolution.py
+++ b/aiohasupervisor/models/resolution.py
@@ -71,6 +71,7 @@ class IssueType(StrEnum):
     PWNED = "pwned"
     REBOOT_REQUIRED = "reboot_required"
     SECURITY = "security"
+    SYSTEMD_UNIT_FAILED = "systemd_unit_failed"
     UPDATE_FAILED = "update_failed"
     UPDATE_ROLLBACK = "update_rollback"
 
@@ -117,10 +118,12 @@ class UnhealthyReason(StrEnum):
     client.
     """
 
+    DATA_FILESYSTEM_CHECK_ERROR = "data_filesystem_check_error"
     DOCKER = "docker"
     DOCKER_GATEWAY_UNPROTECTED = "docker_gateway_unprotected"
     DUPLICATE_OS_INSTALLATION = "duplicate_os_installation"
     OSERROR_BAD_MESSAGE = "oserror_bad_message"
+    OS_FILESYSTEM_CHECK_ERROR = "os_filesystem_check_error"
     PRIVILEGED = "privileged"
     SETUP = "setup"
     SUPERVISOR = "supervisor"
@@ -162,6 +165,7 @@ class CheckType(StrEnum):
     FREE_SPACE = "free_space"
     MULTIPLE_DATA_DISKS = "multiple_data_disks"
     NETWORK_INTERFACE_IPV4 = "network_interface_ipv4"
+    SYSTEMD_UNIT_FAILURE = "systemd_unit_failure"
 
 
 # --- OBJECTS ----


### PR DESCRIPTION
## Changes

Add new enum values to resolution models as introduced in home-assistant/supervisor#6976:

- `UnhealthyReason.DATA_FILESYSTEM_CHECK_ERROR` — set when the data partition fsck fails
- `UnhealthyReason.OS_FILESYSTEM_CHECK_ERROR` — set when the OS/overlay partition fsck fails
- `IssueType.SYSTEMD_UNIT_FAILED` — created for any other failed systemd unit (not managed mounts or firewall)
- `CheckType.SYSTEMD_UNIT_FAILURE` — new check that detects failed systemd units

## Related

- Supervisor PR: home-assistant/supervisor#6976