### PR TITLE
Add version_pending to OS info

### DIFF
--- a/aiohasupervisor/models/os.py
+++ b/aiohasupervisor/models/os.py
@@ -42,6 +42,7 @@ class OSInfo(ResponseData):
 
     version: str | None
     version_latest: str | None
+    version_pending: str | None
     update_available: bool
     board: str | None
     boot: str | None

--- a/tests/fixtures/os_info.json
+++ b/tests/fixtures/os_info.json
@@ -3,6 +3,7 @@
   "data": {
     "version": "13.0",
     "version_latest": "13.1",
+    "version_pending": null,
     "update_available": true,
     "board": "odroid-n2",
     "boot": "B",

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -33,6 +33,7 @@ async def test_os_info(
     info = await supervisor_client.os.info()
     assert info.version == "13.0"
     assert info.version_latest == "13.1"
+    assert info.version_pending is None
     assert info.update_available is True
     assert info.boot_slots["A"].state == "inactive"
     assert info.boot_slots["B"].state == "booted"


### PR DESCRIPTION
## Proposed change

Adds the `version_pending` attribute to the `OSInfo` model, matching the new field exposed by `/os/info` in home-assistant/supervisor#7006.

`version_pending` tracks the version of an installed OS update that awaits a reboot to activate. It is `null` when no update is pending.

## Related

- Supervisor PR: home-assistant/supervisor#7006

🤖 Generated with [Claude Code](https://claude.com/claude-code)