### PR TITLE
Use no timeout for Core lifecycle calls

### DIFF
--- a/aiohasupervisor/homeassistant.py
+++ b/aiohasupervisor/homeassistant.py
@@ -38,18 +38,20 @@ class HomeAssistantClient(_SupervisorComponentClient):
     async def restart(self, options: HomeAssistantRestartOptions | None = None) -> None:
         """Restart Home Assistant."""
         await self._client.post(
-            "core/restart", json=options.to_dict() if options else None
+            "core/restart",
+            json=options.to_dict() if options else None,
+            timeout=None,
         )
 
     async def stop(self, options: HomeAssistantStopOptions | None = None) -> None:
         """Stop Home Assistant."""
         await self._client.post(
-            "core/stop", json=options.to_dict() if options else None
+            "core/stop", json=options.to_dict() if options else None, timeout=None
         )
 
     async def start(self) -> None:
         """Start Home Assistant."""
-        await self._client.post("core/start")
+        await self._client.post("core/start", timeout=None)
 
     async def check_config(self) -> None:
         """Check Home Assistant config."""
@@ -58,5 +60,7 @@ class HomeAssistantClient(_SupervisorComponentClient):
     async def rebuild(self, options: HomeAssistantRebuildOptions | None = None) -> None:
         """Rebuild Home Assistant."""
         await self._client.post(
-            "core/rebuild", json=options.to_dict() if options else None
+            "core/rebuild",
+            json=options.to_dict() if options else None,
+            timeout=None,
         )

--- a/tests/test_homeassistant.py
+++ b/tests/test_homeassistant.py
@@ -15,7 +15,7 @@ from aiohasupervisor.models import (
     HomeAssistantUpdateOptions,
 )
 
-from . import load_fixture
+from . import RequestTimeouts, assert_request_timeout, load_fixture
 from .const import SUPERVISOR_URL
 
 
@@ -75,6 +75,7 @@ async def test_homeassistant_options(
 @pytest.mark.parametrize("options", [None, HomeAssistantUpdateOptions(backup=False)])
 async def test_homeassistant_update(
     responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: HomeAssistantUpdateOptions | None,
 ) -> None:
@@ -82,11 +83,18 @@ async def test_homeassistant_update(
     responses.post(f"{SUPERVISOR_URL}/core/update", status=200)
     assert await supervisor_client.homeassistant.update(options) is None
     assert responses.requests.keys() == {("POST", URL(f"{SUPERVISOR_URL}/core/update"))}
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/update",
+        has_timeout=False,
+    )
 
 
 @pytest.mark.parametrize("options", [None, HomeAssistantRestartOptions(safe_mode=True)])
 async def test_homeassistant_restart(
     responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: HomeAssistantRestartOptions | None,
 ) -> None:
@@ -96,11 +104,18 @@ async def test_homeassistant_restart(
     assert responses.requests.keys() == {
         ("POST", URL(f"{SUPERVISOR_URL}/core/restart"))
     }
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/restart",
+        has_timeout=False,
+    )
 
 
 @pytest.mark.parametrize("options", [None, HomeAssistantStopOptions(force=True)])
 async def test_homeassistant_stop(
     responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: HomeAssistantStopOptions | None,
 ) -> None:
@@ -108,29 +123,52 @@ async def test_homeassistant_stop(
     responses.post(f"{SUPERVISOR_URL}/core/stop", status=200)
     assert await supervisor_client.homeassistant.stop(options) is None
     assert responses.requests.keys() == {("POST", URL(f"{SUPERVISOR_URL}/core/stop"))}
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/stop",
+        has_timeout=False,
+    )
 
 
 async def test_homeassistant_start(
-    responses: aiointercept, supervisor_client: SupervisorClient
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
+    supervisor_client: SupervisorClient,
 ) -> None:
     """Test Home Assistant start API."""
     responses.post(f"{SUPERVISOR_URL}/core/start", status=200)
     assert await supervisor_client.homeassistant.start() is None
     assert responses.requests.keys() == {("POST", URL(f"{SUPERVISOR_URL}/core/start"))}
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/start",
+        has_timeout=False,
+    )
 
 
 async def test_homeassistant_check_config(
-    responses: aiointercept, supervisor_client: SupervisorClient
+    responses: aiointercept,
+    request_timeouts: RequestTimeouts,
+    supervisor_client: SupervisorClient,
 ) -> None:
     """Test Home Assistant check config API."""
     responses.post(f"{SUPERVISOR_URL}/core/check", status=200)
     assert await supervisor_client.homeassistant.check_config() is None
     assert responses.requests.keys() == {("POST", URL(f"{SUPERVISOR_URL}/core/check"))}
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/check",
+        has_timeout=True,
+    )
 
 
 @pytest.mark.parametrize("options", [None, HomeAssistantRebuildOptions(safe_mode=True)])
 async def test_homeassistant_rebuild(
     responses: aiointercept,
+    request_timeouts: RequestTimeouts,
     supervisor_client: SupervisorClient,
     options: HomeAssistantRebuildOptions | None,
 ) -> None:
@@ -140,3 +178,9 @@ async def test_homeassistant_rebuild(
     assert responses.requests.keys() == {
         ("POST", URL(f"{SUPERVISOR_URL}/core/rebuild"))
     }
+    assert_request_timeout(
+        request_timeouts,
+        "POST",
+        f"{SUPERVISOR_URL}/core/rebuild",
+        has_timeout=False,
+    )


### PR DESCRIPTION
## Summary

`restart`, `stop`, `start` and `rebuild` on `HomeAssistantClient` are long-running lifecycle operations, but they inherited `DEFAULT_TIMEOUT = ClientTimeout(total=10)`. This mirrors the fix already in place for `update()`, which passes `timeout=None`.

Especially since https://github.com/home-assistant/supervisor/pull/7018, the restart timeout was probably not very problematic since Core got rejected or restarted immediately anyways. Now that a restart queues behind the start job, the request is held server-side for >10s → `SupervisorTimeoutError`, even though the restart itself succeeds. Passing `timeout=None` removes the spurious error.

`check_config` is intentionally left on the default timeout — it is not a queued lifecycle operation.

## Test plan

- [x] `pytest tests/test_homeassistant.py`
- [x] `ruff check` / `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)